### PR TITLE
Refinements to enable NeXus files for Tristan image data

### DIFF
--- a/src/nexgen/command_line/copy_nexus_from_tristan.py
+++ b/src/nexgen/command_line/copy_nexus_from_tristan.py
@@ -66,14 +66,16 @@ def main():
         CopyTristanNexus.multiple_images_nexus(
             params.input.data_file,
             params.input.tristan_nexus_file,
-            params.input.angular_velocity,
-            params.input.nbins,
+            ang_vel=params.input.angular_velocity,
+            nbins=params.input.nbins,
         )
     elif params.input.experiment_type == "pump-probe":
         print("Pump-probe experiment.")
         print(f"Mode: {params.input.mode}")
         CopyTristanNexus.pump_probe_nexus(
-            params.input.data_file, params.input.tristan_nexus_file, params.input.mode
+            params.input.data_file,
+            params.input.tristan_nexus_file,
+            mode=params.input.mode,
         )
     else:
         sys.exit(f"Please pass a valid experiment type.")

--- a/src/nexgen/copy/CopyTristanNexus.py
+++ b/src/nexgen/copy/CopyTristanNexus.py
@@ -12,7 +12,7 @@ from . import get_nexus_tree, identify_scan_axis, convert_scan_axis
 from .. import create_attributes
 
 
-def single_image_nexus(data_file, tristan_nexus):
+def single_image_nexus(data_file, tristan_nexus, write_mode="x"):
     """
     Copy the nexus tree from the original NeXus file for a collection on Tristan detector.
     In this case the input scan_axis is a tuple with the same start and stop value.
@@ -21,10 +21,15 @@ def single_image_nexus(data_file, tristan_nexus):
     Args:
         data_file:      HDF5 file containing the newly binned images.
         tristan_nexus:  NeXus file with experiment metadata to be copied.
+        write_mode:     Mode for writing the output NeXus file.  Accepts any valid
+                        h5py file opening mode.
+
+    Returns:
+        The name of the output NeXus file.
     """
     nxs_filename = os.path.splitext(data_file)[0] + ".nxs"
     with h5py.File(tristan_nexus, "r") as nxs_in, h5py.File(
-        nxs_filename, "x"
+        nxs_filename, write_mode
     ) as nxs_out:
         # Copy the whole tree except for nxdata
         nxentry = get_nexus_tree(nxs_in, nxs_out)
@@ -48,7 +53,10 @@ def single_image_nexus(data_file, tristan_nexus):
 
     return nxs_filename
 
-def multiple_images_nexus(data_file, tristan_nexus, ang_vel=None, nbins=None):
+
+def multiple_images_nexus(
+    data_file, tristan_nexus, write_mode="x", ang_vel=None, nbins=None
+):
     """
     Copy the nexus tree from the original NeXus file for a collection on Tristan detector.
     In this case multiple images from a rotation collection have been binned.
@@ -59,12 +67,17 @@ def multiple_images_nexus(data_file, tristan_nexus, ang_vel=None, nbins=None):
     Args:
         data_file:      HDF5 file containing the newly binned images.
         tristan_nexus:  NeXus file with experiment metadata to be copied.
+        write_mode:     Mode for writing the output NeXus file.  Accepts any valid
+                        h5py file opening mode.
         ang_vel:        Angular velocity, deg/s.
-        nbins:       Number of binned images.
+        nbins:          Number of binned images.
+
+    Returns:
+        The name of the output NeXus file.
     """
     nxs_filename = os.path.splitext(data_file)[0] + ".nxs"
     with h5py.File(tristan_nexus, "r") as nxs_in, h5py.File(
-        nxs_filename, "x"
+        nxs_filename, write_mode
     ) as nxs_out:
         # Copy the whole tree except for nxdata
         nxentry = get_nexus_tree(nxs_in, nxs_out)
@@ -103,7 +116,8 @@ def multiple_images_nexus(data_file, tristan_nexus, ang_vel=None, nbins=None):
 
     return nxs_filename
 
-def pump_probe_nexus(data_file, tristan_nexus, mode="static"):
+
+def pump_probe_nexus(data_file, tristan_nexus, write_mode="x", mode="static"):
     """
     Copy the nexus tree from the original NeXus file for a collection on Tristan detector.
     In this case multiple images from a pump-probe experiment have been binned.
@@ -114,7 +128,12 @@ def pump_probe_nexus(data_file, tristan_nexus, mode="static"):
     Args:
         data_file:      HDF5 file containing the newly binned images.
         tristan_nexus:  NeXus file with experiment metadata to be copied.
+        write_mode:     Mode for writing the output NeXus file.  Accepts any valid
+                        h5py file opening mode.
         mode:           "static", "powder_diffraction" or "rotation"
+
+    Returns:
+        The name of the output NeXus file.
     """
     # TODO: figure out a better way
     assert mode in [
@@ -125,7 +144,7 @@ def pump_probe_nexus(data_file, tristan_nexus, mode="static"):
 
     nxs_filename = os.path.splitext(data_file)[0] + ".nxs"
     with h5py.File(tristan_nexus, "r") as nxs_in, h5py.File(
-        nxs_filename, "x"
+        nxs_filename, write_mode
     ) as nxs_out:
         # Copy the whole tree except for nxdata
         nxentry = get_nexus_tree(nxs_in, nxs_out)

--- a/src/nexgen/copy/CopyTristanNexus.py
+++ b/src/nexgen/copy/CopyTristanNexus.py
@@ -47,6 +47,7 @@ def single_image_nexus(data_file, tristan_nexus):
         nxsample = nxentry["sample"]
         convert_scan_axis(nxsample, nxdata, ax)
 
+    return nxs_filename
 
 def multiple_images_nexus(data_file, tristan_nexus, ang_vel=None, nbins=None):
     """
@@ -102,6 +103,7 @@ def multiple_images_nexus(data_file, tristan_nexus, ang_vel=None, nbins=None):
         nxsample = nxentry["sample"]
         convert_scan_axis(nxsample, nxdata, ax)
 
+    return nxs_filename
 
 def pump_probe_nexus(data_file, tristan_nexus, mode="static"):
     """
@@ -150,3 +152,5 @@ def pump_probe_nexus(data_file, tristan_nexus, mode="static"):
         # Now fix all other instances of scan_axis in the tree
         nxsample = nxentry["sample"]
         convert_scan_axis(nxsample, nxdata, ax)
+
+    return nxs_filename

--- a/src/nexgen/copy/CopyTristanNexus.py
+++ b/src/nexgen/copy/CopyTristanNexus.py
@@ -31,8 +31,7 @@ def single_image_nexus(data_file, tristan_nexus):
         # Create nxdata group
         nxdata = nxentry.create_group("data")
         # Add link to data
-        with h5py.File(data_file, "r") as fh:
-            nxdata["data"] = h5py.ExternalLink(fh.filename, "data")
+        nxdata["data"] = h5py.ExternalLink(data_file, "data")
         # Compute and write axis information
         ax, ax_attr = identify_scan_axis(nxs_in)
         create_attributes(
@@ -72,8 +71,7 @@ def multiple_images_nexus(data_file, tristan_nexus, ang_vel=None, nbins=None):
         # Create nxdata group
         nxdata = nxentry.create_group("data")
         # Add link to data
-        with h5py.File(data_file, "r") as fh:
-            nxdata["data"] = h5py.ExternalLink(fh.filename, "data")
+        nxdata["data"] = h5py.ExternalLink(data_file, "data")
         # Compute and write axis information
         ax, ax_attr = identify_scan_axis(nxs_in)
         create_attributes(
@@ -134,8 +132,7 @@ def pump_probe_nexus(data_file, tristan_nexus, mode="static"):
         # Create nxdata group
         nxdata = nxentry.create_group("data")
         # Add link to data
-        with h5py.File(data_file, "r") as fh:
-            nxdata["data"] = h5py.ExternalLink(fh.filename, "data")
+        nxdata["data"] = h5py.ExternalLink(data_file, "data")
         # Compute and write axis information
         ax, ax_attr = identify_scan_axis(nxs_in)
         create_attributes(

--- a/src/nexgen/copy/CopyTristanNexus.py
+++ b/src/nexgen/copy/CopyTristanNexus.py
@@ -14,9 +14,11 @@ from .. import create_attributes
 
 def single_image_nexus(data_file, tristan_nexus, write_mode="x"):
     """
-    Copy the nexus tree from the original NeXus file for a collection on Tristan detector.
-    In this case the input scan_axis is a tuple with the same start and stop value.
-    The scan_axis in the new file will therefore be one single value.
+    Create a NeXus file for a single-image data set.
+
+    Copy the nexus tree from the original NeXus file for a collection on Tristan
+    detector. In this case the input scan_axis is a tuple with the same start and
+    stop value. The scan_axis in the new file will therefore be one single value.
 
     Args:
         data_file:      HDF5 file containing the newly binned images.
@@ -58,11 +60,13 @@ def multiple_images_nexus(
     data_file, tristan_nexus, write_mode="x", ang_vel=None, nbins=None
 ):
     """
-    Copy the nexus tree from the original NeXus file for a collection on Tristan detector.
-    In this case multiple images from a rotation collection have been binned.
-    Thus the scan_axis in the input file is a tuple (start, stop).
-    The scan_axis in the new file will therefore be a list of angles.
-    ang_vel and num_bins are mutually exclusive arguments to work out the scan_axis list.
+    Create a NeXus file for a multiple-image data set.
+
+    Copy the nexus tree from the original NeXus file for a collection on Tristan
+    detector. In this case multiple images from a rotation collection have been
+    binned. Thus the scan_axis in the input file is a tuple (start, stop). The
+    scan_axis in the new file will therefore be a list of angles. ang_vel and
+    num_bins are mutually exclusive arguments to work out the scan_axis list.
 
     Args:
         data_file:      HDF5 file containing the newly binned images.
@@ -94,7 +98,8 @@ def multiple_images_nexus(
 
         if ang_vel and nbins:
             raise ValueError(
-                "ang_vel and nbins are mutually exclusive, please pass only one of them."
+                "ang_vel and nbins are mutually exclusive, "
+                "please pass only one of them."
             )
         elif ang_vel:
             ax_range = np.array([round(p, 1) for p in np.arange(start, stop, ang_vel)])
@@ -103,7 +108,8 @@ def multiple_images_nexus(
             ax_range = np.array([round(p, 1) for p in np.arange(start, stop, step)])
         else:
             raise ValueError(
-                "Impossible to calculate scan_axis, please pass either ang_vel or nbins."
+                "Impossible to calculate scan_axis, "
+                "please pass either ang_vel or nbins."
             )
 
         nxdata.create_dataset(ax, data=ax_range)
@@ -119,11 +125,13 @@ def multiple_images_nexus(
 
 def pump_probe_nexus(data_file, tristan_nexus, write_mode="x", mode="static"):
     """
-    Copy the nexus tree from the original NeXus file for a collection on Tristan detector.
-    In this case multiple images from a pump-probe experiment have been binned.
-    Thus the scan_axis in the input file is a tuple (start, stop).
-    The scan_axis in the new file will be a single value if chosen mode is not "rotation".
-    TBD rotation + pump-probe
+    Create a NeXus file for a pump-probe image data set.
+
+    Copy the nexus tree from the original NeXus file for a collection on Tristan
+    detector. In this case multiple images from a pump-probe experiment have been
+    binned. Thus the scan_axis in the input file is a tuple (start, stop). The
+    scan_axis in the new file will be a single value if chosen mode is not
+    "rotation". TBD rotation + pump-probe
 
     Args:
         data_file:      HDF5 file containing the newly binned images.
@@ -136,11 +144,10 @@ def pump_probe_nexus(data_file, tristan_nexus, write_mode="x", mode="static"):
         The name of the output NeXus file.
     """
     # TODO: figure out a better way
-    assert mode in [
-        "static",
-        "powder_diffraction",
-        "rotation",
-    ], "Mode passed is not valid, please pass one of the following ['static', 'powder_diffraction', 'rotation']"
+    assert mode in ["static", "powder_diffraction", "rotation"], (
+        "Mode passed is not valid, please pass one of the following "
+        "['static', 'powder_diffraction', 'rotation']"
+    )
 
     nxs_filename = os.path.splitext(data_file)[0] + ".nxs"
     with h5py.File(tristan_nexus, "r") as nxs_in, h5py.File(


### PR DESCRIPTION
- Allow specification of write mode for output NeXus file.
- Remove unnecessary file read.  When creating an h5py ExternalLink, it is not necessary to hold the target open for reading.
- When making NeXus output, return output file name.