### PR TITLE
Use the Codecov uploader

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -34,7 +34,7 @@ steps:
 - bash: |
     curl -Os https://uploader.codecov.io/latest/linux/codecov
     chmod +x codecov
-    ./codecov -B $(Build.SourceBranchName) -C $(Build.SourceVersion) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
+    ./codecov -B $(Build.SourceBranchName) -C $(Build.SourceVersion) -t $(CODECOV_TOKEN) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
   displayName: 'Publish coverage stats'
   continueOnError: True
   workingDirectory: $(Pipeline.Workspace)/src

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -31,7 +31,10 @@ steps:
   displayName: Run tests
   workingDirectory: $(Pipeline.Workspace)/src
 
-- bash: bash <(curl -s https://codecov.io/bash) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
+- bash: |
+    curl -Os https://uploader.codecov.io/latest/linux/codecov
+    chmod +x codecov
+    ./codecov -B $(Build.SourceBranchName) -C $(Build.SourceVersion) -n "Python $(PYTHON_VERSION) $(Agent.OS)"
   displayName: 'Publish coverage stats'
   continueOnError: True
   workingDirectory: $(Pipeline.Workspace)/src


### PR DESCRIPTION
- Migrate from [the deprecated Codecov Bash uploader](https://docs.codecov.com/docs/about-the-codecov-bash-uploader#deprecation-notice-and-schedule) to [the new pre-built binary uploader](https://docs.codecov.com/docs/codecov-uploader).
- Use the Codecov token, saved as a secret-value variable in the Azure pipeline.  Strictly, [this ought not to be needed](https://docs.codecov.com/docs/codecov-uploader#upload-token), but in practice it seems to be necessary.