### PR TITLE
Fix outstanding extruder issues

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include README.rst
+
+include src/nexgen/beamlines/*.phil

--- a/src/nexgen/beamlines/I24_Eiger.phil
+++ b/src/nexgen/beamlines/I24_Eiger.phil
@@ -1,0 +1,62 @@
+goniometer {
+  axes = omega,sam_z,sam_y,sam_x
+  depends = .,omega,sam_z,sam_y
+  vectors = -1,0,0,0,0,1,0,1,0,1,0,0
+  offsets = 0,0,0,0,0,0,0,0,0,0,0,0
+  offset_units = mm mm mm mm mm mm
+  starts = None
+  ends = None
+  increments = None
+  types = rotation,translation,translation,translation
+  units = deg,mm,mm,mm
+}
+source {
+  name = Diamond Light Source
+  short_name = DLS
+  type = Synchrotron X-ray Source
+  beamline_name = I24
+}
+beam {
+  wavelength = None
+  flux = None
+}
+attenuator {
+  transmission = None
+}
+detector {
+  description = Eiger 2X 9M
+  detector_type = Pixel
+  sensor_material = Si *CdTe
+  sensor_thickness = 0.750mm
+  overload = 50649
+  underload = -1
+  pixel_size = 0.075mm 0.075mm
+  beam_center = None
+  flatfield = None
+  flatfield_applied = False
+  pixel_mask = None
+  pixel_mask_applied = False
+  image_size = 3108,3262
+  exposure_time = None
+  axes = det_z,
+  depends = .
+  vectors = 0,0,1
+  starts = 0.0
+  ends = 0.0
+  increments = 0.0
+  types = translation
+  units = mm
+  software_version = None
+  detector_tick = None
+  detector_frequency = None
+  timeslice_rollover = None
+}
+detector_module {
+  num_modules = 1
+  module_offset = 0 *1 2
+  fast_axis = -1,0,0
+  slow_axis = 0,-1,0
+  offsets = 0,0,0,0,0,0
+  module_size = 0 0
+}
+

--- a/src/nexgen/beamlines/I24_Eiger_nxs.py
+++ b/src/nexgen/beamlines/I24_Eiger_nxs.py
@@ -210,10 +210,12 @@ def write_nxs(**ssx_params):
         num_imgs=ssx_params["num_imgs"],
         beam_center=ssx_params["beam_center"],
         detector_distance=ssx_params["det_dist"],
-        start_time=ssx_params["start_time"].strftime(
-            "%Y-%m-%dT%H:%M:%S"
-        ),  # This should be datetiem type
-        stop_time=ssx_params["stop_time"].strftime("%Y-%m-%dT%H:%M:%S"),  # idem.
+        start_time=ssx_params["start_time"].strftime("%Y-%m-%dT%H:%M:%S")
+        if ssx_params["start_time"]
+        else None,  # This should be datetiem type
+        stop_time=ssx_params["stop_time"].strftime("%Y-%m-%dT%H:%M:%S")
+        if ssx_params["start_time"]
+        else None,  # idem.
         exposure_time=ssx_params["exp_time"],
         transmission=ssx_params["transmission"],
         wavelength=ssx_params["wavelength"],
@@ -289,6 +291,8 @@ if __name__ == "__main__":
         num_imgs=2450,
         beam_center=[1590.7, 1643.7],
         det_dist=0.5,
+        # start_time=None,
+        # stop_time=None,
         start_time=datetime.now(),
         stop_time=datetime.now(),
         exp_time=0.002,

--- a/src/nexgen/beamlines/I24_Eiger_nxs.py
+++ b/src/nexgen/beamlines/I24_Eiger_nxs.py
@@ -13,7 +13,6 @@ import numpy as np
 from typing import List
 from pathlib import Path
 
-# from datetime import datetime
 from collections import namedtuple
 
 from .I24_Eiger_params import goniometer_axes, eiger9M_params, source
@@ -49,11 +48,13 @@ ssx_collect = namedtuple(
         "filename",
         "exp_type",
         "num_imgs",
+        "beam_center",
         "detector_distance",
         "start_time",
         "stop_time",
         "exposure_time",
         "transmission",
+        "wavelength",
         "flux",
         "pump_status",
         "pump_exp",
@@ -192,6 +193,7 @@ def write_nxs(**ssx_params):
         filename=ssx_params["filename"],
         exp_type=ssx_params["exp_type"],
         num_imgs=ssx_params["num_imgs"],
+        beam_center=ssx_params["beam_center"],
         detector_distance=ssx_params["det_dist"],
         start_time=ssx_params["start_time"].strftime(
             "%Y-%m-%dT%H:%M:%S"
@@ -201,6 +203,7 @@ def write_nxs(**ssx_params):
         ),  # idem. A bit of a gorilla but works.
         exposure_time=ssx_params["exp_time"],
         transmission=ssx_params["transmission"],
+        wavelength=ssx_params["wavelength"],
         flux=ssx_params["flux"],
         pump_status=ssx_params["pump_status"],
         pump_exp=ssx_params["pump_exp"],
@@ -210,9 +213,11 @@ def write_nxs(**ssx_params):
     # Add to dictionaries
     detector["starts"] = [SSX.detector_distance]
     detector["exposure_time"] = SSX.exposure_time
+    detector["beam_center"] = SSX.beam_center
 
     attenuator["transmission"] = SSX.transmission
 
+    beam["wavelength"] = SSX.wavelength
     beam["flux"] = SSX.flux
 
     # Find metafile in directory and get info from it
@@ -273,22 +278,24 @@ def write_nxs(**ssx_params):
         grid_scan_3D()
 
 
-# # Example usage
-# if __name__ == "__main__":
-#     write_nxs(
-#         visitpath=sys.argv[1],
-#         filename=sys.argv[2],
-#         exp_type="extruder",
-#         num_imgs=100,
-#         det_dist=0.5,
-#         # start_time="Mon Nov 15 2021 15:59:12",
-#         start_time=datetime.now(),
-#         stop_time=datetime.now(),
-#         # stop_time=None,
-#         exp_time=0.002,
-#         transmission=1.0,
-#         flux=None,
-#         pump_status=False,    # this is a string on the beamline
-#         pump_exp=None,
-#         pump_delay=None,
-#     )
+# Example usage
+if __name__ == "__main__":
+    from datetime import datetime
+
+    write_nxs(
+        visitpath=sys.argv[1],
+        filename=sys.argv[2],
+        exp_type="extruder",
+        num_imgs=100,
+        beam_center=[1590.7, 1643.7],
+        det_dist=0.5,
+        start_time=datetime.now(),
+        stop_time=datetime.now(),
+        exp_time=0.002,
+        transmission=1.0,
+        wavelength=0.649,
+        flux=None,
+        pump_status="false",  # this is a string on the beamline
+        pump_exp=None,
+        pump_delay=None,
+    )

--- a/src/nexgen/beamlines/I24_Eiger_nxs.py
+++ b/src/nexgen/beamlines/I24_Eiger_nxs.py
@@ -226,6 +226,12 @@ def write_nxs(**ssx_params):
         # metafile = SSX.visitpath / (SSX.filename.replace(seq, "meta") + ".h5")
         logger.info(f"Found {metafile} in directory. Looking for metadata ...")
         # Overwrite/add to dictionary
+        # TODO rethink the metafile issue.
+        # This is fine if the collection is short enough that by the time the nexus writing
+        # is triggered all the other files are closed. But it will raise OSError otherwise.
+        # Possible solution: hard code the copied values - should be constant anyway - , make links
+        # and get beam center in namedtuple from the PVs.
+        # pretty much like GDA.
         with h5py.File(metafile, "r") as meta:
             overwrite_beam(meta, detector["description"], beam)
             links = overwrite_detector(meta, detector)

--- a/src/nexgen/beamlines/I24_Eiger_nxs.py
+++ b/src/nexgen/beamlines/I24_Eiger_nxs.py
@@ -244,7 +244,10 @@ def write_nxs(**ssx_params):
         logger.warning(
             "No _meta.h5 file found in directory. External links in the NeXus file will be broken."
         )
-        # sys.exit("Missing metadata, unable to write NeXus file. Please use command line tool.")
+        sys.exit(
+            "Missing metadata, unable to write NeXus file. Please use command line tool."
+        )
+        # TODO add instructions for using command line tool
 
     module["fast_axis"] = detector.pop("fast_axis")
     module["slow_axis"] = detector.pop("slow_axis")

--- a/src/nexgen/beamlines/I24_Eiger_nxs.py
+++ b/src/nexgen/beamlines/I24_Eiger_nxs.py
@@ -15,7 +15,12 @@ from pathlib import Path
 
 from collections import namedtuple
 
-from .I24_Eiger_params import goniometer_axes, eiger9M_params, source, dset_links
+from .I24_Eiger_params import (
+    goniometer_axes,
+    eiger9M_params,
+    source,
+    dset_links,
+)
 
 from .. import (
     get_iso_timestamp,
@@ -28,8 +33,6 @@ from ..nxs_write import (
 )
 from ..nxs_write.NexusWriter import call_writers
 from ..nxs_write.NXclassWriters import write_NXentry, write_NXnote
-
-# from ..tools.MetaReader import overwrite_detector, overwrite_beam
 
 # Define a logger object and a formatter
 logger = logging.getLogger("NeXusGenerator.I24")
@@ -65,7 +68,6 @@ ssx_collect = namedtuple(
 # Initialize dictionaries
 goniometer = goniometer_axes
 detector = eiger9M_params
-# source = source
 module = {}
 beam = {}
 attenuator = {}
@@ -144,14 +146,13 @@ def extruder(
                 source,
                 beam,
                 attenuator,
-                vds="dataset",  # or None if unwanted
+                vds="dataset",
                 metafile=metafile,
                 link_list=dset_links,
             )
 
             # Write pump-probe information if requested
             if SSX.pump_status == "true":
-                # if SSX.pump_status is True:
                 # Assuming pump_ext and pump_delay have been passed
                 assert (
                     SSX.pump_exp and SSX.pump_delay
@@ -218,19 +219,10 @@ def write_nxs(**ssx_params):
 
     # Find metafile in directory and get info from it
     try:
-        # if filename == test_##
         metafile = [
             f for f in SSX.visitpath.iterdir() if SSX.filename + "_meta" in f.as_posix()
         ][0]
-        # if filename == test_##_000001
-        # seq = SSX.filename.split("_")[2]
-        # metafile = SSX.visitpath / (SSX.filename.replace(seq, "meta") + ".h5")
         logger.info(f"Found {metafile} in directory.")
-        # Overwrite/add to dictionary
-        # Not doing this as for long collections it will not work
-        # with h5py.File(metafile, "r") as meta:
-        #     overwrite_beam(meta, detector["description"], beam)
-        #     links = overwrite_detector(meta, detector)
     except IndexError:
         logger.warning(
             "No _meta.h5 file found in directory. External links in the NeXus file will be broken."
@@ -244,15 +236,12 @@ def write_nxs(**ssx_params):
     module["module_offset"] = "1"
 
     # Find datafiles
-    # if filename == test_##
     filename_template = (
         metafile.parent / metafile.name.replace("meta", f"{6*'[0-9]'}")
     ).as_posix()
     filename = [
         Path(f).expanduser().resolve() for f in sorted(glob.glob(filename_template))
     ]
-    # if filename = test_##_000000
-    # filename = [SSX.visitpath / (SSX.filename+".h5")]
 
     # Add some information to logger
     logger.info("Creating a NeXus file for %s ..." % filename)

--- a/src/nexgen/beamlines/I24_Eiger_params.py
+++ b/src/nexgen/beamlines/I24_Eiger_params.py
@@ -23,7 +23,7 @@ eiger9M_params = {
     "detector_type": "Pixel",
     "sensor_material": "CdTe",
     "sensor_thickness": "0.750mm",
-    "overload": 1e07,
+    "overload": "_dectris/countrate_correction_count_cutoff",
     "underload": -1,
     "pixel_size": ["0.075mm", "0.075mm"],
     "flatfield": None,
@@ -37,3 +37,5 @@ eiger9M_params = {
     "fast_axis": [-1, 0, 0],
     "slow_axis": [0, -1, 0],
 }
+
+dset_links = {}

--- a/src/nexgen/beamlines/I24_Eiger_params.py
+++ b/src/nexgen/beamlines/I24_Eiger_params.py
@@ -23,19 +23,38 @@ eiger9M_params = {
     "detector_type": "Pixel",
     "sensor_material": "CdTe",
     "sensor_thickness": "0.750mm",
-    "overload": "_dectris/countrate_correction_count_cutoff",
+    "overload": 50649,  # "_dectris/countrate_correction_count_cutoff",
     "underload": -1,
     "pixel_size": ["0.075mm", "0.075mm"],
-    "flatfield": None,
-    "pixel_mask": None,
+    "flatfield": "flatfield",
+    "flatfield_applied": "_dectris/flatfield_correction_applied",
+    "pixel_mask": "mask",
+    "pixel_mask_applied": "_dectris/pixel_mask_applied",
     "image_size": [3108, 3262],  # (fast, slow)
     "axes": ["det_z"],
     "depends": ["."],
     "vectors": [0, 0, 1],
     "types": ["translation"],
     "units": ["mm"],
+    "bit_depth_readout": "_dectris/bit_depth_readout",
+    "detector_readout_time": "_dectris/detector_readout_time",
+    "threshold_energy": "_dectris/threshold_energy",
+    "software_version": "_dectris/software_version",
+    "serial_number": "_dectris/detector_number",
     "fast_axis": [-1, 0, 0],
     "slow_axis": [0, -1, 0],
 }
 
-dset_links = {}
+dset_links = [
+    [
+        "pixel_mask",
+        "pixel_mask_applied",
+        "flatfield",
+        "flatfield_applied",
+        "threshold_energy",
+        "bit_depth_readout",
+        "detector_readout_time",
+        "serial_number",
+    ],
+    ["software_version"],
+]

--- a/src/nexgen/beamlines/I24_Eiger_params.py
+++ b/src/nexgen/beamlines/I24_Eiger_params.py
@@ -15,6 +15,9 @@ goniometer_axes = {
     "types": ["rotation", "translation", "translation", "translation"],
     "units": ["deg", "mm", "mm", "mm"],
     "offsets": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    "starts": None,
+    "ends": None,
+    "increments": None,
 }
 
 eiger9M_params = {
@@ -36,6 +39,9 @@ eiger9M_params = {
     "vectors": [0, 0, 1],
     "types": ["translation"],
     "units": ["mm"],
+    "starts": None,
+    "ends": None,
+    "increments": None,
     "bit_depth_readout": "_dectris/bit_depth_readout",
     "detector_readout_time": "_dectris/detector_readout_time",
     "threshold_energy": "_dectris/threshold_energy",

--- a/src/nexgen/command_line/nexus_generator.py
+++ b/src/nexgen/command_line/nexus_generator.py
@@ -656,6 +656,8 @@ def write_with_meta_cli(args):
         )
         logger.exception(err)
 
+    logger.info("EOF")
+
 
 # Define subparsers
 subparsers = parser.add_subparsers(

--- a/src/nexgen/command_line/nxs_phil.py
+++ b/src/nexgen/command_line/nxs_phil.py
@@ -179,7 +179,7 @@ beamline_scope = freephil.parse(
       wavelength = 0.979590
         .type = float
         .help = "Wavelength of incident beam, angstroms"
-      flux = 268717230611.358
+      flux = None
         .type = float
         .help = "Flux of incident beam, ph / s"
     }

--- a/src/nexgen/command_line/nxs_phil.py
+++ b/src/nexgen/command_line/nxs_phil.py
@@ -203,6 +203,17 @@ timestamp_scope = freephil.parse(
     """
 )
 
+pump_probe_scope = freephil.parse(
+    """
+    pump_exp = None
+      .type = float
+      .help = "Pump exposure time."
+    pump_delay = None
+      .type = float
+      .help = "Pump delay"
+    """
+)
+
 if __name__ == "__main__":
     print(detector_scope.as_str())
     print(module_scope.as_str())

--- a/src/nexgen/nxs_write/NXclassWriters.py
+++ b/src/nexgen/nxs_write/NXclassWriters.py
@@ -709,6 +709,7 @@ def write_NXnote(nxsfile: h5py.File, loc: str, info: Dict):
 
     # Write datasets
     for k, v in info.items():
-        if type(v) is str:
-            v = np.string_(v)
-        nxnote.create_dataset(k, data=v)
+        if v:  # Just in case one value is not recorded and set as None
+            if type(v) is str:
+                v = np.string_(v)
+            nxnote.create_dataset(k, data=v)

--- a/src/nexgen/nxs_write/data_tools.py
+++ b/src/nexgen/nxs_write/data_tools.py
@@ -110,16 +110,21 @@ def vds_writer(nxsfile: h5py.File, datafiles: List[Path], vds_writer: str):
     """
     data_logger.info("Start creating VDS ...")
     entry_key = "data"
-    sh = h5py.File(datafiles[0], "r")[entry_key].shape
+    # Calculate total number of frames across the files
+    frames = [h5py.File(f, "r")[entry_key].shape[0] for f in datafiles]
+    tot_frames = sum(frames)
+    # Get shape of the detector
+    sh = h5py.File(datafiles[0], "r")[entry_key].shape[1:]
+
     dtyp = h5py.File(datafiles[0], "r")[entry_key].dtype
 
     # Create virtual layout
-    layout = h5py.VirtualLayout(shape=(len(datafiles) * sh[0],) + sh[1:], dtype=dtyp)
+    layout = h5py.VirtualLayout(shape=(tot_frames,) + sh, dtype=dtyp)
     start = 0
-    for _, filename in enumerate(datafiles):
-        end = start + sh[0]
+    for n, filename in enumerate(datafiles):
+        end = start + frames[n]
         vsource = h5py.VirtualSource(
-            filename.name, entry_key, shape=sh
+            filename.name, entry_key, shape=(frames[n],) + sh
         )  # Source definition
         layout[start:end:1, :, :] = vsource
         start = end

--- a/src/nexgen/nxs_write/data_tools.py
+++ b/src/nexgen/nxs_write/data_tools.py
@@ -40,14 +40,16 @@ def data_writer(
 
 
 def generate_image_data(
-    filename: Optional[Union[Path, str]], shape: Tuple[int, int], write_mode: str = "x"
+    filename: Optional[Union[Path, str]],
+    shape: Tuple[int, int, int],
+    write_mode: str = "x",
 ):
     """
     Generate a HDF5 file with blank images.
 
     Args:
         filename:   Name of the output data file to be written.
-        shape:      Tuple defining dataset dimensions.
+        shape:      Tuple defining dataset dimensions as follows: (img_number, slow_axis, fast_axis).
         write_mode: Mode for writing the output HDF5 file.  Accepts any valid
                     h5py file opening mode.
     """


### PR DESCRIPTION
While the nexus file writing works fine (so far, test with beam tbd), a few outstanding issues have been identified during the latest test.

TODO list:

- [x] Fix metafile issue. (This is probably the most urgent) As for longer collections the _meta.h5 file will still be open for writing when the nexus file is triggered, the code currently raises OSError. 
- [x] Check that the number of images and the size of rotation axis array is calculated correctly if there is more than one data file. (ie. every time there are more than 1000 images written)
- [x] Small command line tool to produce a nexus file a posteriori in case something goes wrong during the collection.
- [x] Add a bit more logging 