### PR TITLE
Command line fixes

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,5 +2,6 @@ freephil
 h5py
 hdf5plugin
 numpy
+pint
 pytest
 pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,3 +48,4 @@ libtbx.precommit =
 console_scripts = 
     generate_nexus = nexgen.command_line.nexus_generator:main
     copy_nexus = nexgen.command_line.copy_nexus:main
+    nexgen_phil = nexgen.command_line.phil_files_cli:main

--- a/src/nexgen/__init__.py
+++ b/src/nexgen/__init__.py
@@ -11,6 +11,9 @@ import re
 import sys
 import h5py
 import pint
+
+# import freephil
+
 import numpy as np
 
 from pathlib import Path
@@ -20,6 +23,9 @@ from typing import Any, Optional, List, Union
 # Initialize registry and a Quantity constructor
 ureg = pint.UnitRegistry()
 Q_ = ureg.Quantity
+
+# Define scope extract type
+# Scope = freephil.common.scope_extract
 
 # Filename pattern: filename_######.h5 or filename_meta.h5
 # P = re.compile(r"(.*)_(?:\d+)")

--- a/src/nexgen/beamlines/I19-2_Eiger.phil
+++ b/src/nexgen/beamlines/I19-2_Eiger.phil
@@ -1,20 +1,20 @@
 goniometer {
-  axes = omega sam_z sam_y sam_x
-  depends = . omega sam_z sam_y
-  vectors = -1,0,0,0,0,1,0,1,0,1,0,0
-  offsets = 0,0,0,0,0,0,0,0,0,0,0,0
-  offset_units = mm mm mm mm
+  axes = omega kappa phi sam_z sam_y sam_x
+  depends = . omega kappa phi sam_z sam_y
+  vectors = -1,0,0,-0.642788,-0.766044,0,-1,0,0,0,0,-1,0,-1,0,-1,0,0
+  offsets = 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+  offset_units = mm mm mm mm mm mm
   starts = None
   ends = None
   increments = None
-  types = rotation translation translation translation
-  units = deg mm mm mm
+  types = rotation rotation rotation translation translation translation
+  units = deg deg deg mm mm mm
 }
 source {
   name = Diamond Light Source
   short_name = DLS
   type = Synchrotron X-ray Source
-  beamline_name = I24
+  beamline_name = I19-2
 }
 beam {
   wavelength = None
@@ -29,35 +29,35 @@ pump_probe {
   pump_delay = None
 }
 detector {
-  description = Eiger 2X 9M
+  description = Eiger 2X 4M
   detector_type = Pixel
   sensor_material = Si *CdTe
   sensor_thickness = 0.750mm
-  overload = 50649
-  underload = -1
+  overload = None
+  underload = None
   pixel_size = 0.075mm 0.075mm
   beam_center = None
   flatfield = None
   flatfield_applied = False
   pixel_mask = None
   pixel_mask_applied = False
-  image_size = 3108,3262
+  image_size = 2162,2068
   exposure_time = None
-  axes = det_z
-  depends = .
-  vectors = 0,0,1
+  axes = two_theta det_z
+  depends = . two_theta
+  vectors = -1,0,0,0,0,1
   starts = None
   ends = None
-  increments = 0.0
-  types = translation
-  units = mm
+  increments = 0.0,0.0
+  types = rotation translation
+  units = deg mm
   software_version = None
 }
 detector_module {
   num_modules = 1
   module_offset = 0 *1 2
-  fast_axis = -1,0,0
-  slow_axis = 0,-1,0
+  fast_axis = 0,1,0
+  slow_axis = -1,0,0
   offsets = 0,0,0,0,0,0
   module_size = 0 0
 }

--- a/src/nexgen/beamlines/I19-2_Tristan.phil
+++ b/src/nexgen/beamlines/I19-2_Tristan.phil
@@ -1,0 +1,68 @@
+goniometer {
+  axes = omega kappa phi sam_z sam_y sam_x
+  depends = . omega kappa phi sam_z sam_y
+  vectors = -1,0,0,-0.642788,-0.766044,0,-1,0,0,0,0,-1,0,-1,0,-1,0,0
+  offsets = 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+  offset_units = mm mm mm mm mm mm
+  starts = None
+  ends = None
+  increments = None
+  types = rotation rotation rotation translation translation translation
+  units = deg deg deg mm mm mm
+}
+source {
+  name = Diamond Light Source
+  short_name = DLS
+  type = Synchrotron X-ray Source
+  beamline_name = I19-2
+}
+beam {
+  wavelength = None
+  flux = None
+}
+attenuator {
+  transmission = None
+}
+pump_probe {
+  pump_status = False
+  pump_exp = None
+  pump_delay = None
+}
+detector {
+  description = Tristan 10M
+  detector_type = Pixel
+  sensor_material = *Si CdTe
+  sensor_thickness = 0.0005m
+  overload = None
+  underload = None
+  pixel_size = 5.5e-05m 5.5e-05m
+  beam_center = None
+  flatfield = None
+  flatfield_applied = False
+  pixel_mask = None
+  pixel_mask_applied = False
+  image_size = 4183,3043
+  exposure_time = None
+  axes = two_theta det_z
+  depends = . two_theta
+  vectors = -1,0,0,0,0,1
+  starts = None
+  ends = None
+  increments = 0.0,0.0
+  types = rotation translation
+  units = deg mm
+  software_version = None
+}
+tristanSpec {
+  detector_tick = 1562.5ps
+  detector_frequency = 6.4e+08Hz
+  timeslice_rollover = 18
+}
+detector_module {
+  num_modules = 1
+  module_offset = 0 *1 2
+  fast_axis = -1,0,0
+  slow_axis = 0,1,0
+  offsets = 0,0,0,0,0,0
+  module_size = 0 0
+}

--- a/src/nexgen/beamlines/I24_Eiger.phil
+++ b/src/nexgen/beamlines/I24_Eiger.phil
@@ -47,9 +47,6 @@ detector {
   types = translation
   units = mm
   software_version = None
-  detector_tick = None
-  detector_frequency = None
-  timeslice_rollover = None
 }
 detector_module {
   num_modules = 1

--- a/src/nexgen/beamlines/I24_Eiger_nxs.py
+++ b/src/nexgen/beamlines/I24_Eiger_nxs.py
@@ -281,25 +281,25 @@ def write_nxs(**ssx_params):
 
 
 # Example usage
-# if __name__ == "__main__":
-#     from datetime import datetime
+if __name__ == "__main__":
+    from datetime import datetime
 
-#     write_nxs(
-#         visitpath=sys.argv[1],
-#         filename=sys.argv[2],
-#         exp_type="extruder",
-#         num_imgs=2450,
-#         beam_center=[1590.7, 1643.7],
-#         det_dist=0.5,
-#         # start_time=None,
-#         # stop_time=None,
-#         start_time=datetime.now(),
-#         stop_time=datetime.now(),
-#         exp_time=0.002,
-#         transmission=1.0,
-#         wavelength=0.649,
-#         flux=None,
-#         pump_status="true",  # this is a string on the beamline
-#         pump_exp=None,
-#         pump_delay=None,
-#     )
+    write_nxs(
+        visitpath=sys.argv[1],
+        filename=sys.argv[2],
+        exp_type="extruder",
+        num_imgs=2450,
+        beam_center=[1590.7, 1643.7],
+        det_dist=0.5,
+        # start_time=None,
+        # stop_time=None,
+        start_time=datetime.now(),
+        stop_time=datetime.now(),
+        exp_time=0.002,
+        transmission=1.0,
+        wavelength=0.649,
+        flux=None,
+        pump_status="true",  # this is a string on the beamline
+        pump_exp=None,
+        pump_delay=None,
+    )

--- a/src/nexgen/command_line/__init__.py
+++ b/src/nexgen/command_line/__init__.py
@@ -72,3 +72,17 @@ tristan_group.add_argument(
     help="Number of binnes images",
     type=int,
 )
+
+
+def add_tristan_spec(detector, tristanSpec):
+    """
+    Add metadata specific to LATRD Tristan to detector scope.
+
+    Args:
+        detector (scope_extract):      Scope defining the detector
+        tristanSpec (scope_extract):   Scope defining Tristan specific input
+    """
+    for k, v in tristanSpec.__dict__.items():
+        if "__phil" in k:
+            continue
+        detector.__inject__(k, v)

--- a/src/nexgen/command_line/nexus_generator.py
+++ b/src/nexgen/command_line/nexus_generator.py
@@ -711,4 +711,4 @@ def main():
     args.func(args)
 
 
-# main()
+main()

--- a/src/nexgen/command_line/nexus_generator.py
+++ b/src/nexgen/command_line/nexus_generator.py
@@ -189,7 +189,8 @@ def write_NXmx_cli(args):
     )
 
     # If dealing with a tristan detector, add its specifications to detector scope.
-    # TODO
+    if "TRISTAN" in detector.description.upper():
+        add_tristan_spec(detector, params.tristanSpec)
 
     # Log information
     logger.info("Source information")
@@ -542,7 +543,8 @@ def write_with_meta_cli(args):
     )
 
     # If dealing with a tristan detector, add its specifications to detector scope.
-    # TODO
+    if "TRISTAN" in detector.description.upper():
+        add_tristan_spec(detector, params.tristanSpec)
 
     # Log information
     logger.info("Source information")

--- a/src/nexgen/command_line/nexus_generator.py
+++ b/src/nexgen/command_line/nexus_generator.py
@@ -697,7 +697,8 @@ def write_with_meta_cli(args):
 
 # Define subparsers
 subparsers = parser.add_subparsers(
-    help="Choose whether to write a NXmx NeXus file for a collection or a demo.",
+    help="Choose whether to write a NXmx NeXus file for a collection or a demo. \
+        Run generate_nexus <command> --help to see the parameters for each sub-command.",
     required=True,
     dest="sub-command",
 )

--- a/src/nexgen/command_line/nexus_generator.py
+++ b/src/nexgen/command_line/nexus_generator.py
@@ -20,6 +20,7 @@ from . import (
     detectormode_parser,
     nexus_parser,
     demo_parser,
+    add_tristan_spec,
 )
 from .. import (
     get_nexus_filename,
@@ -187,6 +188,9 @@ def write_NXmx_cli(args):
         get_iso_timestamp(params.end_time),
     )
 
+    # If dealing with a tristan detector, add its specifications to detector scope.
+    # TODO
+
     # Log information
     logger.info("Source information")
     logger.info(f"Facility: {source.name} - {source.type}.")
@@ -349,6 +353,10 @@ def write_demo_cli(args):
     source = params.source
     beam = params.beam
     attenuator = params.attenuator
+
+    # If dealing with a tristan detector, add its specifications to detector scope.
+    if "TRISTAN" in detector.description.upper():
+        add_tristan_spec(detector, params.tristanSpec)
 
     # Log information
     logger.info("Data type: %s" % data_type[0])
@@ -533,7 +541,9 @@ def write_with_meta_cli(args):
         get_iso_timestamp(params.end_time),
     )
 
-    # TODO figure out how to handle logging of detector information in this case
+    # If dealing with a tristan detector, add its specifications to detector scope.
+    # TODO
+
     # Log information
     logger.info("Source information")
     logger.info(f"Facility: {source.name} - {source.type}.")

--- a/src/nexgen/command_line/nexus_generator.py
+++ b/src/nexgen/command_line/nexus_generator.py
@@ -28,6 +28,7 @@ from .. import (
     get_iso_timestamp,
 )
 from ..nxs_write.NexusWriter import write_nexus, write_nexus_demo
+from ..nxs_write.NXclassWriters import write_NXnote
 
 # Define a logger object and a formatter
 logger = logging.getLogger("NeXusGenerator")
@@ -297,6 +298,14 @@ def write_NXmx_cli(args):
                 cf,
                 params.input.vds_writer,
             )
+
+            # Check and save pump status
+            if params.pump_probe.pump_status is True:
+                logger.info(
+                    "Pump probe status is True, write relative metadata as NXnote."
+                )
+                write_NXnote(nxsfile, "/entry/source/notes", params.pump_probe.__dict__)
+
         logger.info(f"{master_file} correctly written.")
     except Exception as err:
         logger.info(
@@ -465,6 +474,13 @@ def write_demo_cli(args):
                 attenuator,
                 params.input.vds_writer,
             )
+
+            # Check and save pump status
+            if params.pump_probe.pump_status is True:
+                logger.info(
+                    "Pump probe status is True, write relative metadata as NXnote."
+                )
+                write_NXnote(nxsfile, "/entry/source/notes", params.pump_probe.__dict__)
 
             # Record string with end_time
             end_time = datetime.fromtimestamp(time.time()).strftime(
@@ -661,6 +677,14 @@ def write_with_meta_cli(args):
                 params.input.vds_writer,
                 metainfo,
             )
+
+            # Check and save pump status
+            if params.pump_probe.pump_status is True:
+                logger.info(
+                    "Pump probe status is True, write relative metadata as NXnote."
+                )
+                write_NXnote(nxsfile, "/entry/source/notes", params.pump_probe.__dict__)
+
             logger.info(f"{master_file} correctly written.")
     except Exception as err:
         logger.info(

--- a/src/nexgen/command_line/nxs_phil.py
+++ b/src/nexgen/command_line/nxs_phil.py
@@ -110,13 +110,13 @@ detector_scope = freephil.parse(
         .help = "Detector software version"
     }
     tristanSpec {
-      detector_tick = 1562.5ps
+      detector_tick = None          # 1562.5ps
         .type = str
         .help = "Tristan specific - detector tick, in ps"
-      detector_frequency = 6.4e+08Hz
+      detector_frequency = None     # 6.4e+08Hz
         .type = str
         .help = "Tristan specific - detector frequency, in Hz"
-      timeslice_rollover = 18
+      timeslice_rollover = None     # 18
         .type = int
         .help = "Tristan specific - timeslice rollover bits"
     }

--- a/src/nexgen/command_line/nxs_phil.py
+++ b/src/nexgen/command_line/nxs_phil.py
@@ -108,6 +108,8 @@ detector_scope = freephil.parse(
       software_version = None
         .type = str
         .help = "Detector software version"
+    }
+    tristanSpec {
       detector_tick = 1562.5ps
         .type = str
         .help = "Tristan specific - detector tick, in ps"
@@ -189,6 +191,17 @@ beamline_scope = freephil.parse(
         .type = float
         .help = "Attenuation of beam intensity"
     }
+    pump_probe {
+      pump_status = False
+        .type = bool
+        .help = "Pump probe experiment status."
+      pump_exp = None
+        .type = float
+        .help = "Pump exposure time"
+      pump_delay = None
+        .type = float
+        .help = "Pump delay"
+    }
     """
 )
 
@@ -200,17 +213,6 @@ timestamp_scope = freephil.parse(
     end_time = None
       .type = str
       .help = "Experiment end time, pass either a timestamp or a string, eg '2021-09-20T10:20:30' or 'Tue Sep 28 2021 10:58:01'."
-    """
-)
-
-pump_probe_scope = freephil.parse(
-    """
-    pump_exp = None
-      .type = float
-      .help = "Pump exposure time."
-    pump_delay = None
-      .type = float
-      .help = "Pump delay"
     """
 )
 

--- a/src/nexgen/command_line/phil_files_cli.py
+++ b/src/nexgen/command_line/phil_files_cli.py
@@ -1,0 +1,119 @@
+"""
+Command line tool to get an existing .phil file with goniometer/detector metadata or to create a new one.
+These files can be used as input for the NeXus generator CLI.
+"""
+
+import shutil
+import argparse
+import freephil
+
+try:
+    from importlib.resources import files
+except ImportError:
+    # Python < 3.9 compatibility
+    from importlib_resources import files
+
+from pathlib import Path
+
+from . import version_parser, nexus_parser
+
+from .. import beamlines
+
+scopes = freephil.parse(
+    """
+    include scope nexgen.command_line.nxs_phil.goniometer_scope
+    include scope nexgen.command_line.nxs_phil.beamline_scope
+    include scope nexgen.command_line.nxs_phil.detector_scope
+    include scope nexgen.command_line.nxs_phil.module_scope
+    """,
+    process_includes=True,
+)
+
+parser = argparse.ArgumentParser(description=__doc__, parents=[version_parser])
+parser.add_argument("--debug", action="store_const", const=True)
+
+
+def list_available_phil():
+    filedir = files(beamlines)
+    for f in filedir.glob("*.phil"):
+        print(f.name)
+
+
+def get_beamline_phil(args):
+    # Determine where to save file
+    if args.output:
+        odir = Path(args.output).expanduser().resolve()
+    else:
+        odir = Path(".").expanduser().resolve()
+        print(
+            "No output directory was specified by user. A copy of the file will be saved in the current directory."
+        )
+
+    # Look for file
+    filedir = files(beamlines)
+    found = [f for f in sorted(filedir.glob("*.phil")) if args.phil_file == f.name]
+    if len(found) == 0:
+        print(f"No {args.phil_file} found.")
+    elif len(found) == 1:
+        print(f"{args.phil_file} found. Copying in {odir}.")
+        shutil.copy(found[0], odir)
+
+
+def create_new_phil(args):
+    cl = scopes.command_line_argument_interpreter()
+    working_phil = scopes.fetch(cl.process_and_fetch(args.phil_args))
+
+    # Write to file
+    if args.filename:
+        filename = Path(args.filename).expanduser().resolve()
+        with open(filename, "w") as fout:
+            fout.write(working_phil.as_str())
+    else:
+        # working_phil.show()
+        print(working_phil.as_str())
+
+
+# Define subparsers
+subparser = parser.add_subparsers(
+    help="Run nexgen_phil <command> --help to see the options for each command.",
+    required=True,
+    dest="command",
+)
+
+parser_list = subparser.add_parser(
+    "list",
+    description=("Print out a list of currently available .phil template files."),
+)
+parser_list.set_defaults(func=list_available_phil)
+
+parser_get = subparser.add_parser(
+    "get",
+    description=(
+        "Get a copy of a .phil file to use as input for the NeXus file writer."
+    ),
+)
+parser_get.add_argument("phil_file", type=str, help="Requested file name.")
+parser_get.add_argument("-o", "--output", type=str, help="Specify output directory.")
+parser_get.set_defaults(func=get_beamline_phil)
+
+parser_create = subparser.add_parser(
+    "new",
+    description=("Write a new .phil file."),
+    parents=[nexus_parser],
+)
+parser_create.add_argument(
+    "-f", "--filename", type=str, help="Filename for new .phil template."
+)
+# parser_create.add_argument("phil_args", nargs="*")
+parser_create.set_defaults(func=create_new_phil)
+
+
+def main():
+    args = parser.parse_args()
+    if args.command == "list":
+        args.func()
+    else:
+        args.func(args)
+
+
+main()

--- a/src/nexgen/nxs_write/NXclassWriters.py
+++ b/src/nexgen/nxs_write/NXclassWriters.py
@@ -673,7 +673,7 @@ def write_NXcollection(
             grp.create_dataset(
                 "software_version", data=np.string_(detector["software_version"])
             )
-    if "TRISTAN" in detector["description"].upper() or data_type[1] == "events":
+    if "TRISTAN" in detector["description"].upper():  # or data_type[1] == "events":
         tick = ureg.Quantity(detector["detector_tick"])
         grp.create_dataset("detector_tick", data=tick.magnitude)
         grp["detector_tick"].attrs["units"] = format(tick.units, "~")

--- a/src/nexgen/nxs_write/NXclassWriters.py
+++ b/src/nexgen/nxs_write/NXclassWriters.py
@@ -659,6 +659,7 @@ def write_NXcollection(
         meta (Path):                Path to _meta.h5 file, if exists.
         link_list (List):           List of values from the meta file to be linked instead of copied.
     """
+    NXclass_logger.info("Start writing detectorSpecific group as NXcollection.")
     # Create detectorSpecific group
     grp = nxdetector.create_group("detectorSpecific")
     grp.create_dataset("x_pixels", data=detector["image_size"][0])
@@ -696,6 +697,7 @@ def write_NXnote(nxsfile: h5py.File, loc: str, info: Dict):
         loc (str):              Location inside the NeXus file to write NXnote group.
         info (Dict):            Dictionary of datasets to be written to NXnote.
     """
+    NXclass_logger.info("Start writing NXnote.")
     # Create the NXnote group in the specified location
     try:
         nxnote = nxsfile.create_group(loc)
@@ -713,3 +715,4 @@ def write_NXnote(nxsfile: h5py.File, loc: str, info: Dict):
             if type(v) is str:
                 v = np.string_(v)
             nxnote.create_dataset(k, data=v)
+            NXclass_logger.info(f"{k} dataset writte in {loc}.")


### PR DESCRIPTION
There are a couple of things to be checked to make sure that the command line tools work well in general. (as of 0.5.11 it looks like they do the job with a few quirks)
There is also a need for a way to generate the nexus file from the command line if something goes wrong during the collection, asap for I24. 

- [x] Fix command line tools to work from beamlines
- [x] detector_scope from nxs_phil needs a bit of reviewing
- [x] Add a small tool to generate phil files to be used as input for nexus_generator