### PR TITLE
Be more prescriptive in finding the scan axis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,13 +7,21 @@ repos:
   - id: black
     args: [--safe, --quiet]
 
-# Some basic Flake8
+# Sort imports
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+  - id: isort
+    name: isort (python)
+    args: ['--profile=black', '--add_imports="from __future__ import annotations']
+
+# Linting
 - repo: https://github.com/pycqa/flake8
   rev: 4.0.1
   hooks:
   - id: flake8
-    args: [ '--max-line-length=88', '--select=E401,E711,E712,E713,E714,E721,E722,E901,F401,F402,F403,F405,F631,F632,F633,F811,F812,F821,F822,F841,F901,W191,W291,W292,W293,W602,W603,W604,W605,W606' ]
-
+    additional_dependencies: ['flake8-comprehensions==3.8.0']
+    args: ['--ignore=E203,E266,F403,F401,E402,E501,W503,E741']
 
   # Other syntax checks
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,19 +2,25 @@ repos:
 
 # Automatic source code formatting
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 22.3.0
   hooks:
   - id: black
     args: [--safe, --quiet]
 
-# Syntax check and some basic flake8
+# Some basic Flake8
+- repo: https://github.com/pycqa/flake8
+  rev: 4.0.1
+  hooks:
+  - id: flake8
+    args: [ '--max-line-length=88', '--select=E401,E711,E712,E713,E714,E721,E722,E901,F401,F402,F403,F405,F631,F632,F633,F811,F812,F821,F822,F841,F901,W191,W291,W292,W293,W602,W603,W604,W605,W606' ]
+
+
+  # Other syntax checks
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.0.0
+  rev: v4.2.0
   hooks:
   - id: check-ast
   - id: check-yaml
-  - id: flake8
-    args: ['--max-line-length=88', '--select=E401,E711,E712,E713,E714,E721,E722,E901,F401,F402,F403,F405,F631,F632,F633,F811,F812,F821,F822,F841,F901,W191,W291,W292,W293,W602,W603,W604,W605,W606']
   - id: check-merge-conflict
   - id: check-added-large-files
     args: ['--maxkb=200']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ import sys
 sys.path.insert(0, os.path.abspath(".."))
 
 import sphinx_rtd_theme  # noqa; F401 - install theme
+
 import nexgen
 
 # -- General configuration ---------------------------------------------

--- a/src/nexgen/__init__.py
+++ b/src/nexgen/__init__.py
@@ -8,14 +8,13 @@ __version__ = "0.6.6"
 __version_tuple__ = tuple(int(x) for x in __version__.split("."))
 
 import re
-import h5py
-import pint
-
-import numpy as np
-
-from pathlib import Path
 from datetime import datetime
-from typing import Any, Optional, List, Union
+from pathlib import Path
+from typing import Any, List, Optional, Union
+
+import h5py
+import numpy as np
+import pint
 
 # Initialize registry and a Quantity constructor
 ureg = pint.UnitRegistry()

--- a/src/nexgen/beamlines/I19_2_nxs.py
+++ b/src/nexgen/beamlines/I19_2_nxs.py
@@ -3,42 +3,31 @@ Create a NeXus file for time-resolved collections on I19-2.
 Available detectors: Tristan 10M, Eiger 2X 4M.
 """
 
-import sys
-
-import h5py
 import glob
 import logging
-
-from pathlib import Path
-
+import sys
 from collections import namedtuple
 from datetime import datetime
-from typing import Union, Tuple
+from pathlib import Path
+from typing import Tuple, Union
 
-from .I19_2_params import (
-    source,
-    goniometer_axes,
-    tristan10M_params,
-    eiger4M_params,
-    dset_links,
-)
+import h5py
 
-from .. import (
-    get_iso_timestamp,
-    get_nexus_filename,
-)
-
-from ..nxs_write import (
-    calculate_rotation_scan_range,
-)
-
+from .. import get_iso_timestamp, get_nexus_filename
+from ..nxs_write import calculate_rotation_scan_range
 from ..nxs_write.NexusWriter import call_writers
 from ..nxs_write.NXclassWriters import write_NXdatetime, write_NXentry
-
 from ..tools.ExtendedRequest import ExtendedRequestIO
 from ..tools.GDAjson2params import (
-    read_geometry_from_json,
     read_detector_params_from_json,
+    read_geometry_from_json,
+)
+from .I19_2_params import (
+    dset_links,
+    eiger4M_params,
+    goniometer_axes,
+    source,
+    tristan10M_params,
 )
 
 # Define a logger object and a formatter
@@ -399,9 +388,10 @@ def write_nxs(**tr_params):
 
 
 def main():
-    " Call from the beamline"
+    "Call from the beamline"
     # Not the best but it should do the job
     import argparse
+
     from ..command_line import version_parser
 
     parser = argparse.ArgumentParser(description=__doc__, parents=[version_parser])

--- a/src/nexgen/beamlines/I24_Eiger_nxs.py
+++ b/src/nexgen/beamlines/I24_Eiger_nxs.py
@@ -1,35 +1,23 @@
 """
 Create a NeXus file for serial crystallography datasets collected on I24 Eiger 2X 9M detector.
 """
-import sys
-
 import glob
-import h5py
 import logging
+import sys
+from collections import namedtuple
+from pathlib import Path
+from typing import List
+
+import h5py
+
+from .. import get_iso_timestamp, get_nexus_filename
+from ..nxs_write.NexusWriter import ScanReader, call_writers
+from ..nxs_write.NXclassWriters import write_NXdatetime, write_NXentry, write_NXnote
+from ..tools.VDS_tools import image_vds_writer
+from .I24_Eiger_params import dset_links, eiger9M_params, goniometer_axes, source
 
 # import numpy as np
 
-from typing import List
-from pathlib import Path
-
-from collections import namedtuple
-
-from .I24_Eiger_params import (
-    goniometer_axes,
-    eiger9M_params,
-    source,
-    dset_links,
-)
-
-from .. import (
-    get_iso_timestamp,
-    get_nexus_filename,
-)
-
-from ..nxs_write.NexusWriter import call_writers, ScanReader
-from ..nxs_write.NXclassWriters import write_NXentry, write_NXnote, write_NXdatetime
-
-from ..tools.VDS_tools import image_vds_writer
 
 # Define a logger object and a formatter
 logger = logging.getLogger("NeXusGenerator.I24")

--- a/src/nexgen/beamlines/SSX_Tristan_nxs.py
+++ b/src/nexgen/beamlines/SSX_Tristan_nxs.py
@@ -2,22 +2,17 @@
 Create a NeXus file for serial crystallography datasets collected on I19-2 Tristan10M detector.
 """
 
-import sys
-import h5py
 import logging
-
-from pathlib import Path
+import sys
 from collections import namedtuple
+from pathlib import Path
 
-from .I19_2_params import goniometer_axes, tristan10M_params, source
+import h5py
 
-from .. import (
-    get_iso_timestamp,
-    get_nexus_filename,
-)
-
+from .. import get_iso_timestamp, get_nexus_filename
 from ..nxs_write.NexusWriter import call_writers
-from ..nxs_write.NXclassWriters import write_NXentry, write_NXnote, write_NXdatetime
+from ..nxs_write.NXclassWriters import write_NXdatetime, write_NXentry, write_NXnote
+from .I19_2_params import goniometer_axes, source, tristan10M_params
 
 # Define a logger object and a formatter
 logger = logging.getLogger("NeXusGenerator.I19-2_ssx")

--- a/src/nexgen/command_line/__init__.py
+++ b/src/nexgen/command_line/__init__.py
@@ -1,7 +1,6 @@
 """General utilities for comamnd line tools"""
 
 import argparse
-
 from pathlib import Path
 
 from .. import __version__

--- a/src/nexgen/command_line/copy_nexus.py
+++ b/src/nexgen/command_line/copy_nexus.py
@@ -2,20 +2,15 @@
 Command line tool to copy experiment metadata from one NeXus file to the other.
 """
 
-import sys
-import logging
 import argparse
-import freephil
-
+import logging
+import sys
 from pathlib import Path
 
-from . import (
-    version_parser,
-    full_copy_parser,
-    tristan_copy_parser,
-)
+import freephil
 
 from ..nxs_copy import CopyNexus, CopyTristanNexus
+from . import full_copy_parser, tristan_copy_parser, version_parser
 
 # Define a logger object and a formatter
 logger = logging.getLogger("CopyNeXus")
@@ -92,6 +87,7 @@ parser.add_argument(
     dest="attributes_level",
     help="Set the attributes level for showing the configuration parameters.",
 )
+
 
 # CLIs
 def copy_nexus(args):
@@ -182,7 +178,7 @@ def copy_tristan_nexus(args):
                 logger.info(f"Scan_ axis will be a list of {args.num_bins} values.")
             else:
                 logger.error(
-                    f"For a rotation dataset please pass either the oscillation angle or the number of bins."
+                    "For a rotation dataset please pass either the oscillation angle or the number of bins."
                 )
                 sys.exit(
                     "Missing input argument for rotation dataset. Please specify either oscillation angle or number of bins."

--- a/src/nexgen/command_line/nexus_generator.py
+++ b/src/nexgen/command_line/nexus_generator.py
@@ -2,45 +2,39 @@
 Command line tool to generate NeXus files.
 """
 
-import sys
-import glob
-import h5py
-import time
-import logging
 import argparse
-import freephil
+import glob
+import logging
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
 
+import freephil
+import h5py
 import numpy as np
 
-from pathlib import Path
-from datetime import datetime
-
-from . import (
-    version_parser,
-    detectormode_parser,
-    nexus_parser,
-    demo_parser,
-    add_tristan_spec,
-)
 from .. import (
-    get_nexus_filename,
     get_filename_template,
     get_iso_timestamp,
+    get_nexus_filename,
     units_of_time,
 )
-
-from ..nxs_write.NexusWriter import (
-    call_writers,
+from ..nxs_write.NexusWriter import (  # write_nexus_demo, write_nexus
     ScanReader,
-)  # write_nexus_demo, write_nexus
-from ..nxs_write.NXclassWriters import (
-    write_NXnote,
-    write_NXdatetime,
-    write_NXentry,
+    call_writers,
 )
-from ..tools.DataWriter import generate_image_files, generate_event_files
-from ..tools.VDS_tools import image_vds_writer, vds_file_writer
+from ..nxs_write.NXclassWriters import write_NXdatetime, write_NXentry, write_NXnote
+from ..tools.DataWriter import generate_event_files, generate_image_files
 from ..tools.MetaReader import overwrite_beam, overwrite_detector
+from ..tools.VDS_tools import image_vds_writer, vds_file_writer
+from . import (
+    add_tristan_spec,
+    demo_parser,
+    detectormode_parser,
+    nexus_parser,
+    version_parser,
+)
 
 # Define a logger object and a formatter
 logger = logging.getLogger("NeXusGenerator")
@@ -177,6 +171,7 @@ parser.add_argument(
     dest="attributes_level",
     help="Set the attributes level for showing the configuration parameters.",
 )
+
 
 # CLIs
 def write_NXmx_cli(args):
@@ -351,7 +346,7 @@ def write_NXmx_cli(args):
     logger.info(f"Fast axis at datum position: {module.fast_axis}")
     logger.info(f"Slow_axis at datum position: {module.slow_axis}")
     if module.module_offset == "0":
-        logger.warning(f"module_offset field will not be written.")
+        logger.warning("module_offset field will not be written.")
     logger.info("")
 
     logger.info("Start writing NeXus file ...")
@@ -860,7 +855,7 @@ def write_with_meta_cli(args):
     logger.info(f"Fast axis at datum position: {module.fast_axis}")
     logger.info(f"Slow_axis at datum position: {module.slow_axis}")
     if module.module_offset == "0":
-        logger.warning(f"module_offset field will not be written.")
+        logger.warning("module_offset field will not be written.")
     logger.info("")
 
     if args.no_ow:

--- a/src/nexgen/command_line/phil_files_cli.py
+++ b/src/nexgen/command_line/phil_files_cli.py
@@ -3,9 +3,10 @@ Command line tool to get an existing .phil file with goniometer/detector metadat
 These files can be used as input for the NeXus generator CLI.
 """
 
-import sys
-import shutil
 import argparse
+import shutil
+import sys
+
 import freephil
 
 try:
@@ -16,9 +17,8 @@ except ImportError:
 
 from pathlib import Path
 
-from . import version_parser, nexus_parser
-
 from .. import beamlines
+from . import nexus_parser, version_parser
 
 scopes = freephil.parse(
     """

--- a/src/nexgen/nxs_copy/CopyNexus.py
+++ b/src/nexgen/nxs_copy/CopyNexus.py
@@ -2,15 +2,15 @@
 General tools to copy metadata from NeXus files.
 """
 
-import h5py
 import logging
-
 from pathlib import Path
-from typing import Union, Optional, List
+from typing import List, Optional, Union
 
-from . import get_nexus_tree
+import h5py
+
 from .. import get_nexus_filename
 from ..nxs_write import create_attributes
+from . import get_nexus_tree
 
 copy_logger = logging.getLogger("CopyNeXus.copy")
 

--- a/src/nexgen/nxs_copy/CopyTristanNexus.py
+++ b/src/nexgen/nxs_copy/CopyTristanNexus.py
@@ -2,15 +2,15 @@
 Tools for copying the metadata from Tristan NeXus files.
 """
 
-import h5py
 import logging
+from pathlib import Path
+from typing import Optional, Union
+
+import h5py
 import numpy as np
 
-from pathlib import Path
-from typing import Union, Optional
-
-from . import get_nexus_tree, identify_tristan_scan_axis, convert_scan_axis
 from ..nxs_write import create_attributes
+from . import convert_scan_axis, get_nexus_tree, identify_tristan_scan_axis
 
 tristan_logger = logging.getLogger("CopyNeXus.tristan")
 

--- a/src/nexgen/nxs_copy/__init__.py
+++ b/src/nexgen/nxs_copy/__init__.py
@@ -30,7 +30,7 @@ def get_nexus_tree(
     nxs_in: h5py.File,
     nxs_out: h5py.File,
     skip: bool = True,
-    skip_obj: List[str] = ["NXdata"],
+    skip_obj: list[str] = None,
 ):
     """
     Copy the tree from the original NeXus file. Everything except NXdata is copied to a new NeXus file.
@@ -46,6 +46,8 @@ def get_nexus_tree(
         nxentry:    NeXus field.
         Nothing if the full file is copied.
     """
+    skip_obj = ["NXdata"] if skip_obj is None else skip_obj
+
     if skip is True:
         nxentry = nxs_out.create_group("entry")
         create_attributes(nxentry, ("NX_class", "default"), ("NXentry", "data"))

--- a/src/nexgen/nxs_copy/__init__.py
+++ b/src/nexgen/nxs_copy/__init__.py
@@ -4,10 +4,10 @@ Utilities for copying metadata to new NeXus files.
 
 from __future__ import annotations
 
+from typing import Any
+
 import h5py
 import numpy as np
-
-from typing import Any
 
 from .. import walk_nxs
 from ..nxs_write import create_attributes

--- a/src/nexgen/nxs_write/NXclassWriters.py
+++ b/src/nexgen/nxs_write/NXclassWriters.py
@@ -2,32 +2,28 @@
 Writer functions for different groups of a NeXus file.
 """
 
-import h5py
 import logging
-
-import numpy as np
-
-from hdf5plugin import Bitshuffle
-from pathlib import Path
 from datetime import datetime
-from typing import List, Dict, Tuple, Union, Optional
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
 
-from . import (
-    calculate_origin,
-    create_attributes,
-    set_dependency,
-)
+import h5py
+import numpy as np
+from hdf5plugin import Bitshuffle
+
 from .. import (
+    get_iso_timestamp,
     imgcif2mcstas,
     split_arrays,
-    get_iso_timestamp,
     units_of_length,
     units_of_time,
     ureg,
 )
+from . import calculate_origin, create_attributes, set_dependency
 
 NXclass_logger = logging.getLogger("NeXusGenerator.writer.NXclass")
 NXclass_logger.setLevel(logging.DEBUG)
+
 
 # NXentry writer
 def write_NXentry(nxsfile: h5py.File, definition: str = "NXmx") -> h5py.Group:

--- a/src/nexgen/nxs_write/NexusWriter.py
+++ b/src/nexgen/nxs_write/NexusWriter.py
@@ -2,39 +2,37 @@
 Writer for NeXus format files.
 """
 
-import h5py
 import logging
-
-import numpy as np
-
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
 
+import h5py
+import numpy as np
+
+from .. import units_of_time
+from ..tools.DataWriter import generate_event_files, generate_image_files
+from ..tools.MetaReader import overwrite_beam, overwrite_detector
+from ..tools.VDS_tools import image_vds_writer, vds_file_writer
 from . import (
-    find_osc_axis,
+    calculate_grid_scan_range,
     calculate_rotation_scan_range,
     find_grid_scan_axes,
-    calculate_grid_scan_range,
     find_number_of_images,
+    find_osc_axis,
 )
-from .. import units_of_time
-
 from .NXclassWriters import (
-    write_NXentry,
     write_NXdata,
+    write_NXdatetime,
+    write_NXdetector,
+    write_NXdetector_module,
+    write_NXentry,
     write_NXinstrument,
     write_NXsample,
     write_NXsource,
-    write_NXdetector,
-    write_NXdetector_module,
-    write_NXdatetime,
 )
 
-from ..tools.MetaReader import overwrite_beam, overwrite_detector
-from ..tools.DataWriter import generate_event_files, generate_image_files
-from ..tools.VDS_tools import image_vds_writer, vds_file_writer
-
 writer_logger = logging.getLogger("NeXusGenerator.writer")
+
 
 # General writing
 # TODO REMOVE. Hopefully obsolete

--- a/src/nexgen/nxs_write/__init__.py
+++ b/src/nexgen/nxs_write/__init__.py
@@ -3,13 +3,12 @@ Utilities for writing new NeXus format files.
 """
 
 import math
+from pathlib import Path
+from typing import Dict, List, Tuple, Union
+
 import h5py
 import numpy as np
-
-from pathlib import Path
 from h5py import AttributeManager
-from typing import List, Dict, Tuple, Union
-
 from scanspec.core import Path as ScanPath
 from scanspec.specs import Line
 

--- a/src/nexgen/tools/DataWriter.py
+++ b/src/nexgen/tools/DataWriter.py
@@ -2,15 +2,14 @@
 General tools for blank data writing.
 """
 
-import h5py
-import time
 import logging
-
-import numpy as np
-
+import time
 from pathlib import Path
-from hdf5plugin import Bitshuffle
 from typing import List, Tuple, Union
+
+import h5py
+import numpy as np
+from hdf5plugin import Bitshuffle
 
 data_logger = logging.getLogger("NeXusGenerator.writer.data")
 

--- a/src/nexgen/tools/ExtendedRequest.py
+++ b/src/nexgen/tools/ExtendedRequest.py
@@ -3,7 +3,6 @@ IO tool to gather beamline and collection information from xml file.
 """
 
 import xml.etree.ElementTree as ET
-
 from pathlib import Path
 from typing import Dict, Tuple, Union
 

--- a/src/nexgen/tools/GDAjson2params.py
+++ b/src/nexgen/tools/GDAjson2params.py
@@ -2,9 +2,8 @@
 Tools to extract goniometer and detector parameters from GDA JSON files.
 """
 import json
-
-from typing import Dict, Tuple, Union
 from pathlib import Path
+from typing import Dict, Tuple, Union
 
 
 def read_geometry_from_json(

--- a/src/nexgen/tools/MetaReader.py
+++ b/src/nexgen/tools/MetaReader.py
@@ -2,13 +2,12 @@
 Tools to get the information stored inside the _meta.h5 file and overwrite the phil scope.
 """
 
-import h5py
 import logging
+from typing import Any, List
 
-from typing import List, Any
+import h5py
 
 from .. import units_of_length
-
 from .Metafile import DectrisMetafile, TristanMetafile
 
 # TODO actually define the type for scope extract and replace Any with Union
@@ -115,8 +114,8 @@ def overwrite_detector(
             new_values["beam_center"] = meta.get_beam_center()
             overwrite_logger.warning("Beam_center will be overwritten.")
             overwrite_logger.info(
-                f"Values for x and y beam center position found in meta file: %s"
-                % new_values["beam_center"]
+                f"Values for x and y beam center position found in meta file: "
+                f"{new_values['beam_center']}"
             )
             sensor_info = meta.get_sensor_information()
             new_values["sensor_material"] = sensor_info[0]
@@ -132,7 +131,7 @@ def overwrite_detector(
             new_values["overload"] = meta.get_saturation_value()
             overwrite_logger.warning("Saturation value (overload) will be overwritten.")
             overwrite_logger.info(
-                f"Value for overload found in meta file: %s" % new_values["overload"]
+                f"Value for overload found in meta file: {new_values['overload']}"
             )
     else:
         overwrite_logger.warning("Unknown detector, exit.")

--- a/src/nexgen/tools/Metafile.py
+++ b/src/nexgen/tools/Metafile.py
@@ -3,9 +3,9 @@ Define a Metafile object to describe the _meta.h5 file and get the necessary inf
 """
 
 import re
-import h5py
+from typing import List, Tuple, Union
 
-from typing import Union, List, Tuple
+import h5py
 
 try:
     # Only for Python version >= 3.8

--- a/src/nexgen/tools/VDS_tools.py
+++ b/src/nexgen/tools/VDS_tools.py
@@ -2,13 +2,12 @@
 Tools to write Virtual DataSets
 """
 
-import h5py
 import logging
-
-import numpy as np
-
 from pathlib import Path
 from typing import Any, List, Tuple, Union
+
+import h5py
+import numpy as np
 
 vds_logger = logging.getLogger("NeXusGenerator.writer.vds")
 

--- a/tests/test_NXclassWriters.py
+++ b/tests/test_NXclassWriters.py
@@ -1,12 +1,10 @@
 import tempfile
+from datetime import datetime
+
 import h5py
 import pytest
 
-from datetime import datetime
-from nexgen.nxs_write.NXclassWriters import (
-    write_NXdetector_module,
-    write_NXdatetime,
-)
+from nexgen.nxs_write.NXclassWriters import write_NXdatetime, write_NXdetector_module
 
 test_module = {"fast_axis": [1, 0, 0], "slow_axis": [0, 1, 0]}
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,9 +1,9 @@
-import nexgen
+import time
+from pathlib import Path
 
 import pint
-import time
 
-from pathlib import Path
+import nexgen
 
 ureg = pint.UnitRegistry()
 

--- a/tests/test_write_tools.py
+++ b/tests/test_write_tools.py
@@ -1,11 +1,11 @@
 import numpy as np
 
 from nexgen.nxs_write import (
-    calculate_origin,
-    find_osc_axis,
-    find_grid_scan_axes,
-    calculate_rotation_scan_range,
     calculate_grid_scan_range,
+    calculate_origin,
+    calculate_rotation_scan_range,
+    find_grid_scan_axes,
+    find_osc_axis,
     set_dependency,
 )
 
@@ -64,26 +64,20 @@ def test_find_scan_axes():
     )
 
     # Just one scan axis (linear scan)
-    assert (
-        find_grid_scan_axes(
-            test_goniometer["axes"][:3],
-            test_goniometer["starts"][:3],
-            test_goniometer["ends"][:3],
-            test_goniometer["types"][:3],
-        )
-        == ["sam_y"]
-    )
+    assert find_grid_scan_axes(
+        test_goniometer["axes"][:3],
+        test_goniometer["starts"][:3],
+        test_goniometer["ends"][:3],
+        test_goniometer["types"][:3],
+    ) == ["sam_y"]
 
     # Grid scan
-    assert (
-        find_grid_scan_axes(
-            test_goniometer["axes"],
-            test_goniometer["starts"],
-            test_goniometer["ends"],
-            test_goniometer["types"],
-        )
-        == ["sam_y", "sam_x"]
-    )
+    assert find_grid_scan_axes(
+        test_goniometer["axes"],
+        test_goniometer["starts"],
+        test_goniometer["ends"],
+        test_goniometer["types"],
+    ) == ["sam_y", "sam_x"]
 
 
 def test_calc_rotation_range():


### PR DESCRIPTION
Avoid mis-identifying HDF5 dataset objects under `/entry/data` as the scan axis data set unless they have the appropriate `transformation_type` attribute.

- Avoid mis-identifying the scan axis data set under `/entry/data` by  explicitly checking for the `transformation_type` attribute.
- Ensure that the return value of `identify_tristan_scan_axis` is always  defined.
- Specify return types.
- Allow for the possibility that there is no scan axis recorded in  `/entry/data`.
- Make miscellanous houskeeping changes.