### PR TITLE
Fix show-config in parser

### DIFF
--- a/src/nexgen/command_line/__init__.py
+++ b/src/nexgen/command_line/__init__.py
@@ -13,6 +13,24 @@ version_parser.add_argument(
     version=f"%(prog)s: NeXus generation tools {__version__}",
 )
 
+config_parser = argparse.ArgumentParser(add_help=False)
+config_parser.add_argument(
+    "-c",
+    "--show-config",
+    action="store_true",
+    default=False,
+    dest="show_config",
+    help="Show the configuration parameters.",
+)
+config_parser.add_argument(
+    "-a",
+    "--attributes-level",
+    default=0,
+    type=int,
+    dest="attributes_level",
+    help="Set the attributes level for showing the configuration parameters.",
+)
+
 detectormode_parser = argparse.ArgumentParser(add_help=False)
 group = detectormode_parser.add_mutually_exclusive_group(required=True)
 group.add_argument(

--- a/src/nexgen/command_line/copy_nexus.py
+++ b/src/nexgen/command_line/copy_nexus.py
@@ -11,7 +11,7 @@ import freephil
 
 from .. import log
 from ..nxs_copy import CopyNexus, CopyTristanNexus
-from . import full_copy_parser, tristan_copy_parser, version_parser
+from . import config_parser, full_copy_parser, tristan_copy_parser, version_parser
 
 # Define a logger object and a formatter
 logger = logging.getLogger("nexgen.CopyNeXus")
@@ -70,22 +70,6 @@ parser = argparse.ArgumentParser(
 )
 
 parser.add_argument("--debug", action="store_const", const=True)
-parser.add_argument(
-    "-c",
-    "--show-config",
-    action="store_true",
-    default=False,
-    dest="show_config",
-    help="Show the configuration parameters.",
-)
-parser.add_argument(
-    "-a",
-    "--attributes-level",
-    default=0,
-    type=int,
-    dest="attributes_level",
-    help="Set the attributes level for showing the configuration parameters.",
-)
 
 
 # CLIs
@@ -93,7 +77,6 @@ def copy_nexus(args):
     clai = general_scope.command_line_argument_interpreter()
     working_phil = general_scope.fetch(clai.process_and_fetch(args.phil_args))
     params = working_phil.extract()
-    working_phil.show()
 
     if args.show_config:
         working_phil.show(attributes_level=args.attributes_level)
@@ -140,7 +123,6 @@ def copy_tristan_nexus(args):
     clai = tristan_scope.command_line_argument_interpreter()
     working_phil = tristan_scope.fetch(clai.process_and_fetch(args.phil_args))
     params = working_phil.extract()
-    working_phil.show()
 
     if args.show_config:
         working_phil.show(attributes_level=args.attributes_level)
@@ -216,7 +198,7 @@ parser_general = subparsers.add_parser(
     "gen",
     aliases=["copy-file"],
     description=("Copy experiment metadata to a new NeXus file."),
-    parents=[full_copy_parser],
+    parents=[full_copy_parser, config_parser],
 )
 parser_general.set_defaults(func=copy_nexus)
 
@@ -226,7 +208,7 @@ parser_tristan = subparsers.add_parser(
     description=(
         "Create a new NeXus file for binned images by copying the metadata from the original experiment NeXus file."
     ),
-    parents=[tristan_copy_parser],
+    parents=[tristan_copy_parser, config_parser],
 )
 parser_tristan.set_defaults(func=copy_tristan_nexus)
 

--- a/src/nexgen/command_line/nexus_generator.py
+++ b/src/nexgen/command_line/nexus_generator.py
@@ -154,22 +154,6 @@ parser = argparse.ArgumentParser(
     parents=[version_parser],
 )
 parser.add_argument("--debug", action="store_const", const=True)
-# parser.add_argument(
-#     "-c",
-#     "--show-config",
-#     action="store_true",
-#     default=False,
-#     dest="show_config",
-#     help="Show the configuration parameters.",
-# )
-# parser.add_argument(
-#     "-a",
-#     "--attributes-level",
-#     default=0,
-#     type=int,
-#     dest="attributes_level",
-#     help="Set the attributes level for showing the configuration parameters.",
-# )
 
 
 # CLIs

--- a/src/nexgen/command_line/nexus_generator.py
+++ b/src/nexgen/command_line/nexus_generator.py
@@ -31,6 +31,7 @@ from ..tools.MetaReader import overwrite_beam, overwrite_detector
 from ..tools.VDS_tools import image_vds_writer, vds_file_writer
 from . import (
     add_tristan_spec,
+    config_parser,
     demo_parser,
     detectormode_parser,
     nexus_parser,
@@ -153,22 +154,22 @@ parser = argparse.ArgumentParser(
     parents=[version_parser],
 )
 parser.add_argument("--debug", action="store_const", const=True)
-parser.add_argument(
-    "-c",
-    "--show-config",
-    action="store_true",
-    default=False,
-    dest="show_config",
-    help="Show the configuration parameters.",
-)
-parser.add_argument(
-    "-a",
-    "--attributes-level",
-    default=0,
-    type=int,
-    dest="attributes_level",
-    help="Set the attributes level for showing the configuration parameters.",
-)
+# parser.add_argument(
+#     "-c",
+#     "--show-config",
+#     action="store_true",
+#     default=False,
+#     dest="show_config",
+#     help="Show the configuration parameters.",
+# )
+# parser.add_argument(
+#     "-a",
+#     "--attributes-level",
+#     default=0,
+#     type=int,
+#     dest="attributes_level",
+#     help="Set the attributes level for showing the configuration parameters.",
+# )
 
 
 # CLIs
@@ -935,15 +936,18 @@ parser_NXmx = subparsers.add_parser(
     "1",
     aliases=["nexus"],
     description=("Trigger NeXus file writing pointing to existing data."),
-    parents=[nexus_parser],
+    parents=[nexus_parser, config_parser],
 )
 parser_NXmx.set_defaults(func=write_NXmx_cli)
 
 parser_NXmx_demo = subparsers.add_parser(
     "2",
     aliases=["demo"],
-    description=("Trigger NeXus and blank data file writing."),
-    parents=[demo_parser, detectormode_parser],
+    description=(
+        "Trigger NeXus and blank data file writing. "
+        "This option always requires either the -i or -e flags, which are mutually exclusive arguments."
+    ),
+    parents=[demo_parser, detectormode_parser, config_parser],
 )
 parser_NXmx_demo.set_defaults(func=write_demo_cli)
 
@@ -953,7 +957,7 @@ parser_NXmx_meta = subparsers.add_parser(
     description=(
         "Trigger NeXus file writing pointing to an existing collection with a meta file."
     ),
-    parents=[nexus_parser],
+    parents=[nexus_parser, config_parser],
 )
 parser_NXmx_meta.add_argument(
     "-no",

--- a/src/nexgen/command_line/phil_files_cli.py
+++ b/src/nexgen/command_line/phil_files_cli.py
@@ -19,7 +19,7 @@ except ImportError:
 from pathlib import Path
 
 from .. import beamlines, log
-from . import nexus_parser, version_parser
+from . import config_parser, nexus_parser, version_parser
 
 # Define a logger object
 logger = logging.getLogger("nexgen.NeXusGenerator")
@@ -36,22 +36,6 @@ scopes = freephil.parse(
 
 parser = argparse.ArgumentParser(description=__doc__, parents=[version_parser])
 parser.add_argument("--debug", action="store_const", const=True)
-parser.add_argument(
-    "-c",
-    "--show-config",
-    action="store_true",
-    default=False,
-    dest="show_config",
-    help="Show the configuration parameters.",
-)
-parser.add_argument(
-    "-a",
-    "--attributes-level",
-    default=0,
-    type=int,
-    dest="attributes_level",
-    help="Set the attributes level for showing the configuration parameters.",
-)
 
 
 def list_available_phil():
@@ -133,7 +117,7 @@ parser_get.set_defaults(func=get_beamline_phil)
 parser_create = subparser.add_parser(
     "new",
     description=("Write a new .phil file."),
-    parents=[nexus_parser],
+    parents=[nexus_parser, config_parser],
 )
 parser_create.add_argument(
     "-f", "--filename", type=str, help="Filename for new .phil template."


### PR DESCRIPTION
In the CLI the -c/-a options are broken with some subcommands. 
In particular they seem to be problematic for `generate_nexus 2`, while `generate_nexus -c -a 2 3` does exactly what it's supposed to. 
It's also not entirely clear how to use them from looking at argparse --help. They appear in the main one but won't work without the subcommand.
It's probably best to have a separate parser with these options which can be added as parent to each subparser (also avoids repetition in the different CL scripts).