### PR TITLE
Fix general copy functions

### DIFF
--- a/src/nexgen/__init__.py
+++ b/src/nexgen/__init__.py
@@ -87,22 +87,27 @@ def get_filename_template(input_filename: Path) -> str:
     return filename_template.as_posix()
 
 
-def get_nexus_filename(input_filename: Path) -> Path:
+def get_nexus_filename(input_filename: Path, copy: bool = False) -> Path:
     """
     Get the filename for the NeXus file from the stem of the input file name.
 
     Args:
         input_filename (Path): File name and path of either a .h5 data file or a _meta.h5 file.
+        copy (bool, optional): Avoid trying to write a new file with the same name as the old one when making a copy. Defaults to False.
 
     Returns:
-        nxs_filename (Path): NeXus file name (.nxs) path.
+        Path: NeXus file name (.nxs) path.
     """
     filename_stem = P.fullmatch(input_filename.stem)
     if filename_stem:
         filename = filename_stem[1]
     else:
         filename = input_filename.stem
-    nxs_filename = input_filename.parent / f"{filename}.nxs"
+
+    if copy is True:
+        nxs_filename = input_filename.parent / f"{filename}_copy.nxs"
+    else:
+        nxs_filename = input_filename.parent / f"{filename}.nxs"
     return nxs_filename
 
 

--- a/src/nexgen/nxs_copy/CopyNexus.py
+++ b/src/nexgen/nxs_copy/CopyNexus.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import h5py
 
@@ -18,7 +18,7 @@ copy_logger = logging.getLogger("nexgen.CopyNeXus")
 
 def images_nexus(
     data_file: List[Path | str],
-    original_nexus: Optional[Path | str],
+    original_nexus: Path | str,
     simple_copy: bool = True,
     skip_group: List[str] = ["NXdata"],
 ) -> str:
@@ -27,7 +27,7 @@ def images_nexus(
 
     Args:
         data_file (List[Path  |  str]): HDF5 file with images.
-        original_nexus (Optional[Path  |  str]): Original NeXus file with experiment metadata.
+        original_nexus (Path  |  str): Original NeXus file with experiment metadata.
         simple_copy (bool, optional): Copy everything from the original NeXus file. Defaults to True.
         skip_group (List[str], optional): If simple_copy is False, list of NX_class objects to skip when copying.
                                         Defaults to ["NXdata"].
@@ -76,14 +76,14 @@ def images_nexus(
 
 def pseudo_events_nexus(
     data_file: List[Path | str],
-    original_nexus: Optional[Path | str],
+    original_nexus: Path | str,
 ) -> str:
     """
     Copy NeXus metadata for pseudo event mode data.
 
     Args:
         data_file (List[Path  |  str]): HDF5 with pseud event data.
-        original_nexus (Optional[Path  |  str]): Original NeXus file with experiment metadata.
+        original_nexus (Path  |  str): Original NeXus file with experiment metadata.
 
     Returns:
         nxs_filename (str): Filename of new NeXus file.

--- a/src/nexgen/nxs_copy/CopyNexus.py
+++ b/src/nexgen/nxs_copy/CopyNexus.py
@@ -1,10 +1,11 @@
 """
 General tools to copy metadata from NeXus files.
 """
+from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional
 
 import h5py
 
@@ -16,26 +17,28 @@ copy_logger = logging.getLogger("nexgen.CopyNeXus")
 
 
 def images_nexus(
-    data_file: List[Union[Path, str]],
-    original_nexus: Optional[Union[Path, str]],
+    data_file: List[Path | str],
+    original_nexus: Optional[Path | str],
     simple_copy: bool = True,
     skip_group: List[str] = ["NXdata"],
-):
+) -> str:
     """
     Copy NeXus metadata for images.
 
     Args:
-        data_file:      String or Path pointing to the HDF5 file with images.
-        original_nexus: String or Path pointing to the NeXus file with experiment metadata.
-        simple_copy:    Defaults to True, copy everything from the original NeXus file.
-                        If False, a list of NX_class objects to be skipped should be passed.
-        skip_group:     If simple_copy is False, this is a list of the objects not to be copied.
-                        For the moment, works only for NX_class objects.
+        data_file (List[Path  |  str]): HDF5 file with images.
+        original_nexus (Optional[Path  |  str]): Original NeXus file with experiment metadata.
+        simple_copy (bool, optional): Copy everything from the original NeXus file. Defaults to True.
+        skip_group (List[str], optional): If simple_copy is False, list of NX_class objects to skip when copying.
+                                        Defaults to ["NXdata"].
+
+    Returns:
+        nxs_filename (str): Filename of new NeXus file.
     """
     copy_logger.info("Copying NeXus file for image dataset ...")
     data_file = [Path(d).expanduser().resolve() for d in data_file]
     original_nexus = Path(original_nexus).expanduser().resolve()
-    nxs_filename = get_nexus_filename(data_file[0])
+    nxs_filename = get_nexus_filename(data_file[0], copy=True)
     copy_logger.info(f"New NeXus file name: {nxs_filename}")
     with h5py.File(original_nexus, "r") as nxs_in, h5py.File(
         nxs_filename, "x"
@@ -72,20 +75,23 @@ def images_nexus(
 
 
 def pseudo_events_nexus(
-    data_file: List[Union[Path, str]],
-    original_nexus: Optional[Union[Path, str]],
-):
+    data_file: List[Path | str],
+    original_nexus: Optional[Path | str],
+) -> str:
     """
     Copy NeXus metadata for pseudo event mode data.
 
     Args:
-        data_file:       String or Path pointing to the HDF5 file with pseudo event data.
-        original_nexus:  String or Path pointing to the NeXus file with experiment metadata.
+        data_file (List[Path  |  str]): HDF5 with pseud event data.
+        original_nexus (Optional[Path  |  str]): Original NeXus file with experiment metadata.
+
+    Returns:
+        nxs_filename (str): Filename of new NeXus file.
     """
     copy_logger.info("Copying NeXus file for events dataset ...")
     data_file = [Path(d).expanduser().resolve() for d in data_file]
     original_nexus = Path(original_nexus).expanduser().resolve()
-    nxs_filename = get_nexus_filename(data_file[0])
+    nxs_filename = get_nexus_filename(data_file[0], copy=True)
     copy_logger.info(f"New NeXus file name: {nxs_filename}")
     with h5py.File(original_nexus, "r") as nxs_in, h5py.File(
         nxs_filename, "x"

--- a/src/nexgen/nxs_copy/CopyTristanNexus.py
+++ b/src/nexgen/nxs_copy/CopyTristanNexus.py
@@ -1,10 +1,10 @@
 """
 Tools for copying the metadata from Tristan NeXus files.
 """
+from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Optional, Union
 
 import h5py
 import numpy as np
@@ -16,8 +16,8 @@ tristan_logger = logging.getLogger("nexgen.CopyTristanNeXus")
 
 
 def single_image_nexus(
-    data_file: Optional[Union[Path, str]],
-    tristan_nexus: Optional[Union[Path, str]],
+    data_file: Path | str,
+    tristan_nexus: Path | str,
     write_mode: str = "x",
 ) -> str:
     """
@@ -83,8 +83,8 @@ def single_image_nexus(
 
 
 def multiple_images_nexus(
-    data_file: Optional[Union[Path, str]],
-    tristan_nexus: Optional[Union[Path, str]],
+    data_file: Path | str,
+    tristan_nexus: Path | str,
     write_mode: str = "x",
     osc: float = None,
     nbins: int = None,


### PR DESCRIPTION
There's an issue when simply copying metadata from one file to a new one. 
At the moment the function tries to create a new NeXus file with the same name as the original one, leading to OSError.

This is not an issue with the Tristan functions.