### PR TITLE
Fix mask and flatfield writing

### DIFF
--- a/src/nexgen/beamlines/I19_2_gda_nxs.py
+++ b/src/nexgen/beamlines/I19_2_gda_nxs.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 from pathlib import Path
 from typing import Tuple
 
-import h5py
+from hdf5plugin import Bitshuffle  # noqa: F401
 
 from .. import get_iso_timestamp, get_nexus_filename, log
 from ..nxs_write import calculate_scan_range
@@ -28,6 +28,9 @@ from .I19_2_params import (
     source,
     tristan10M_params,
 )
+
+import h5py  # isort: skip
+
 
 # Define a logger object and a formatter
 logger = logging.getLogger("nexgen.I19-2_NeXus_gda")

--- a/src/nexgen/nxs_write/NXclassWriters.py
+++ b/src/nexgen/nxs_write/NXclassWriters.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
-import h5py
 import numpy as np
 from hdf5plugin import Bitshuffle
 
@@ -20,6 +19,9 @@ from .. import (
     ureg,
 )
 from . import calculate_origin, create_attributes, set_dependency
+
+import h5py  # isort: skip
+
 
 NXclass_logger = logging.getLogger("nexgen.NXclass_writers")
 NXclass_logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
Fix plugin issue when copying mask and flatfield by importing filter before h5py. This should get it to find the correct plugins to write the datasets.