### PR TITLE
I24 SSX fixed target fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+##
+
+### Changed
+- Chip definition in SSX tools.
+- WORKAROUND: Define end position of goniometer for a 2d scan (fixed target) on I24 as (end - increment) to avoind scanspec miscalculating the scan values.
+
+### Fixed
+- Cast n_exposures for I24 fixed target experiment to int.
+
+
+---
 ## 0.6.12
 
 ### Added
@@ -22,6 +33,7 @@
 ### Fixed
 - Outstanding data_size order issues.
 - Sample depends_on bug in NXsample writer: the value can now be passed as input argument to write_NXsample. If absent, it will default to the last axis in the goniometer list.
+
 
 ---
 ## 0.6.11

--- a/src/nexgen/beamlines/I24_Eiger_nxs.py
+++ b/src/nexgen/beamlines/I24_Eiger_nxs.py
@@ -322,7 +322,7 @@ def fixed_target(
             )
 
     else:
-        N = chip_info["N_EXPOSURES"][1]
+        N = int(chip_info["N_EXPOSURES"][1])
         logger.info(f"Each position has been collected {N} times.")
         pump_repeat = int(chip_info["PUMP_REPEAT"][1])
         logger.info(f"Pump repeat setting: {pump_repeat}")

--- a/src/nexgen/beamlines/I24_Eiger_nxs.py
+++ b/src/nexgen/beamlines/I24_Eiger_nxs.py
@@ -215,7 +215,7 @@ def fixed_target(
         ],
     )
 
-    goniometer["increments"] = [0.0, 0.0, 0.0, 0.0]
+    goniometer["increments"] = [0.0, 0.0, chip.step_size[1], chip.step_size[0]]
     # Read chip map
     blocks = read_chip_map(
         chipmap,
@@ -236,7 +236,9 @@ def fixed_target(
     TRANSL = {"sam_y": np.array([]), "sam_x": np.array([])}
     for s, e in zip(start_pos.values(), end_pos.values()):
         goniometer["starts"] = s
-        goniometer["ends"] = e
+        goniometer["ends"] = [
+            end - inc for end, inc in zip(e, goniometer["increments"])
+        ]  # Workaround for scanspec issue (we don't want to write the actual end of the chip)
         osc, transl = ScanReader(
             goniometer,
             n_images=(

--- a/src/nexgen/beamlines/SSX_chip.py
+++ b/src/nexgen/beamlines/SSX_chip.py
@@ -33,8 +33,23 @@ class Chip:
 
     start_pos: List[float, float, float] = field(default_factory=[0.0, 0.0, 0.0])
 
-    def tot_blocks(self):
+    def tot_blocks(self) -> int:
         return self.num_blocks[0] * self.num_blocks[1]
+
+    def tot_windows_per_block(self) -> int:
+        return self.num_steps[0] * self.num_steps[1]
+
+    def window_size(self) -> Tuple[float]:
+        return (
+            self.num_steps[0] * self.step_size[0],
+            self.num_steps[1] * self.step_size[1],
+        )
+
+    def chip_size(self) -> Tuple[float]:
+        return (
+            self.num_blocks[0] * self.block_size[0],
+            self.num_blocks[1] * self.block_size[1],
+        )
 
 
 def read_chip_map(mapfile: Path | str, x_blocks: int, y_blocks: int) -> Dict:

--- a/src/nexgen/beamlines/SSX_chip.py
+++ b/src/nexgen/beamlines/SSX_chip.py
@@ -29,7 +29,7 @@ class Chip:
     num_steps: List[int, int] | Tuple[int, int]
     step_size: List[float, float] | Tuple[float, float]
     num_blocks: List[int, int] | Tuple[int, int]
-    block_size: List[int, int] | Tuple[int, int]
+    block_size: List[float, float] | Tuple[float, float]
 
     start_pos: List[float, float, float] = field(default_factory=[0.0, 0.0, 0.0])
 

--- a/tests/test_SSX_chip.py
+++ b/tests/test_SSX_chip.py
@@ -20,6 +20,11 @@ def test_chip_tot_blocks():
     assert test_chip.tot_blocks() == 4
 
 
+def test_chip_windows():
+    assert test_chip.tot_windows_per_block() == 400
+    assert test_chip.window_size() == (2.5, 2.5)
+
+
 def test_chip_types():
     assert type(test_chip.num_steps[0]) is int
     assert type(test_chip.step_size[0]) is float

--- a/tests/test_SSX_chip.py
+++ b/tests/test_SSX_chip.py
@@ -20,6 +20,13 @@ def test_chip_tot_blocks():
     assert test_chip.tot_blocks() == 4
 
 
+def test_chip_types():
+    assert type(test_chip.num_steps[0]) is int
+    assert type(test_chip.step_size[0]) is float
+    assert type(test_chip.num_blocks[0]) is int
+    assert type(test_chip.block_size[0]) is float
+
+
 def test_no_chip_map_passed_returns_fullchip():
     res = read_chip_map(None, 1, 1)
     assert type(res) is dict


### PR DESCRIPTION
Following test on beamline, a couple of fixes/improvements:

- [x] Cast N_EXPOSURES as int - in the input dictionary it's a str.
- [x] Check and fix scan calculation. Since scanspec also writes the "end" value (which we don't write because we start counting from 0), it ignores the increment passed and this leads to the wrong step between windows.


Fixing this might help issue #55 .