### PR TITLE
#87 Don't use unused datasets as VDS source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Changed
 - Chipmap set to None if the inut value from the beamline is "fullchip", indicating that the whole chip is being scanned. The reason for this change is that
 the mapping lite is not used when the fullchip option is selected on the beamline and consequently the chipmap file is not updated.
+- In VDS_tools.split_datasets(), checks if the dataset is actually used in the VDS before adding it to the list so that unused datasets are not used as sources for the VDS
+
 ### Fixed
 - Ensure that the detector distance is always saved in meters and the unit is correct.
 

--- a/tests/test_VDS_tools.py
+++ b/tests/test_VDS_tools.py
@@ -48,7 +48,6 @@ def test_when_get_frames_and_shape_greater_than_1000_non_zero_then_correct():
 def test_when_get_frames_and_shape_greater_than_1000_non_zero_greater_than_1000_then_correct():
     sshape = split_datasets(["test1", "test2"], (1500, 10, 10), 1200)
     assert sshape == [
-        Dataset("test1", (1000, 10, 10), 1000),
         Dataset("test2", (500, 10, 10), 200),
     ]
 
@@ -60,7 +59,6 @@ def test_when_get_frames_and_shape_much_greater_than_1000_non_zero_greater_than_
         ["test1", "test2", "test3", "test4"], (3100, 10, 10), 1100
     )
     assert returned == [
-        Dataset("test1", (1000, 10, 10), 1000),
         Dataset("test2", (1000, 10, 10), 100),
         Dataset("test3", (1000, 10, 10), 0),
         Dataset("test4", (100, 10, 10), 0),


### PR DESCRIPTION
In `VDS_tools.split_datasets()`, checks if the dataset is actually used in the VDS before adding it to the list so that unused datasets are not used as sources for the VDS
And adds a function to clean any linked datasets which are not used in the VDS