### PR TITLE
I19-2 nexus fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-##
+## 0.6.16
 
 ### Added
 - NXdetector test.
@@ -13,6 +13,7 @@ the mapping lite is not used when the fullchip option is selected on the beamlin
 
 ### Fixed
 - Ensure that the detector distance is always saved in meters and the unit is correct.
+- Fix sample_depends_on on I19-2 cli.
 
 ## 0.6.15
 

--- a/src/nexgen/beamlines/I19_2_gda_nxs.py
+++ b/src/nexgen/beamlines/I19_2_gda_nxs.py
@@ -188,6 +188,7 @@ def tristan_writer(
                 beam,
                 attenuator,
                 OSC,
+                sample_depends_on=scan_axis,
             )
 
             # write_NXdatetime(nxsfile, (None, timestamps[1]))
@@ -266,6 +267,7 @@ def eiger_writer(
                 transl_scan=None,
                 metafile=TR.meta_file,
                 link_list=dset_links,
+                sample_depends_on=scan_axis,
             )
 
             if timestamps[1]:

--- a/src/nexgen/beamlines/I19_2_nxs.py
+++ b/src/nexgen/beamlines/I19_2_nxs.py
@@ -170,6 +170,7 @@ def tristan_writer(
                 beam,
                 attenuator,
                 OSC,
+                sample_depends_on=scan_axis,
             )
 
             if timestamps[1]:
@@ -312,6 +313,7 @@ def eiger_writer(
                 transl_scan=None,
                 metafile=TR.meta_file,
                 link_list=dset_links,
+                sample_depends_on=scan_axis,
             )
 
             if timestamps[1]:

--- a/src/nexgen/nxs_write/NXclassWriters.py
+++ b/src/nexgen/nxs_write/NXclassWriters.py
@@ -195,8 +195,8 @@ def write_NXsample(
         data_type (Tuple[str, int]): Images or events.
         osc_scan (Dict[str, ArrayLike]): Rotation scan. If writing events, this is just a (start, end) tuple.
         transl_scan (Dict[str, ArrayLike], optional): Scan along the xy axes at sample. Defaults to None.
-        sample_depends_on (str): Axis on which the sample depends on. If absent, the depends_on field will be set to the last axis listed in the goniometer. Defaults to None.
-        sample_details (Dict[str, Any]): General information about the sample, eg. name, temperature.
+        sample_depends_on (str, optional): Axis on which the sample depends on. If absent, the depends_on field will be set to the last axis listed in the goniometer. Defaults to None.
+        sample_details (Dict[str, Any], optional): General information about the sample, eg. name, temperature.
     """
     NXclass_logger.info("Start writing NXsample and NXtransformations.")
     # Create NXsample group, unless it already exists, in which case just open it.

--- a/src/nexgen/nxs_write/NexusWriter.py
+++ b/src/nexgen/nxs_write/NexusWriter.py
@@ -176,6 +176,7 @@ def call_writers(
     transl_scan: Dict[str, ArrayLike] = None,
     metafile: Path | str = None,
     link_list: List = None,
+    sample_depends_on: str = None,
 ):
     """
     Call the writers for the NeXus base classes.
@@ -195,6 +196,7 @@ def call_writers(
         transl_scan (Dict[str, ArrayLike], optional): Axes defining a linear or 2D scan. Defaults to None.
         metafile (Path | str, optional): File containing the metadata. Defaults to None.
         link_list (List, optional): List of datasets that can be copied from the metafile. Defaults to None.
+        sample_depends_on (str, optional): Axis on which the sample depends on. Defaults to None.
     """
     logger = logging.getLogger("nexgen.Call")
     logger.setLevel(logging.DEBUG)
@@ -262,6 +264,7 @@ def call_writers(
         data_type,
         osc_scan,
         transl_scan,
+        sample_depends_on,
     )
 
 


### PR DESCRIPTION
As a result of changing the way sample_depends_on is written, I19-2 wasn't updated and points to `sam_x` instead of `phi` for the sample depends_on field (`entry/sample/depends_on`).  