### PR TITLE
Singla VDS hack

### DIFF
--- a/src/nexgen/tools/VDS_tools.py
+++ b/src/nexgen/tools/VDS_tools.py
@@ -175,7 +175,19 @@ def image_vds_writer(
     # entry_key = "data"
     dset_names = find_datasets_in_file(nxdata)
 
-    datasets = split_datasets(dset_names, full_data_shape, start_index)
+    # Hack for datasets with no maximum number of frames (eg. Singla)
+    if (
+        len(dset_names) == 1 and nxdata[dset_names[0]].shape[0] > MAX_FRAMES_PER_DATASET
+    ):  # .maxshape[0] is None
+        datasets = [
+            Dataset(
+                name=dset_names[0],
+                source_shape=full_data_shape,
+                start_index=start_index,
+            )
+        ]
+    else:
+        datasets = split_datasets(dset_names, full_data_shape, start_index)
 
     layout = create_virtual_layout(datasets, data_type)
 

--- a/src/nexgen/tools/VDS_tools.py
+++ b/src/nexgen/tools/VDS_tools.py
@@ -176,9 +176,9 @@ def image_vds_writer(
     dset_names = find_datasets_in_file(nxdata)
 
     # Hack for datasets with no maximum number of frames (eg. Singla)
-    if (
-        len(dset_names) == 1 and nxdata[dset_names[0]].shape[0] > MAX_FRAMES_PER_DATASET
-    ):  # .maxshape[0] is None
+    if len(dset_names) == 1 and full_data_shape[0] > MAX_FRAMES_PER_DATASET:
+        # nxdata[dset_names[0]].shape[0] > MAX_FRAMES_PER_DATASET
+        # .maxshape[0] is None
         datasets = [
             Dataset(
                 name=dset_names[0],


### PR DESCRIPTION
So, it seems that Singla datasets have maxshape set to None, and there is no maximum of 1000 frames per file. However the VDS writer assumes this when splitting the datasets and for a longer singla collection every frame with a higher index is not included in the vds
eg. for what should be a 1200 frame collection : 
```Grey-Area work :( $ h5ls -rv ../20230110_1406_nav66_-64.187.93._120DEG_10FPS_50c2.nxs/entry/data/data
Opened "../20230110_1406_nav66_-64.187.93._120DEG_10FPS_50c2.nxs" with sec2 driver.
entry/data/data          Dataset {1000/1000, 1062/1062, 1028/1028}
    Location:  1:2973892
    Links:     1
    Maps:      {1} Source {
                      .   /entry/data/data_000001
               }
    Storage:   2183472000 logical bytes, 0 allocated bytes
    Type:      native unsigned short```