### PR TITLE
Fix bitshuffle deprecation warning 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+##
+
+### Changed
+- FIxed the hdf5plugin.Bitshuffle deprecation warning when writing a compressed mask with LZ4 filter. For the moment, hdf5plugin version pinned to 4.0.1 minimum.
+
 ## 0.6.17
 
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 freephil==0.2.1
 h5py==3.6.0
-hdf5plugin==3.2.0
+hdf5plugin==4.0.1
 numpy==1.21.4
 pint==0.18
 scanspec==0.5.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 freephil==0.2.1
 h5py==3.6.0
-hdf5plugin==3.2.0
+hdf5plugin==4.0.1
 numpy==1.21.4
 pint==0.18
 scanspec==0.5.3

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -3,7 +3,7 @@ sphinx-rtd-theme==1.0.0
 numpy==1.21.4
 pint==0.18
 h5py==3.6.0
-hdf5plugin==3.2.0
+hdf5plugin==4.0.1
 freephil==0.2.1
 importlib_resources==5.6.0
 scanspec==0.5.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ include_package_data = True
 install_requires =
     freephil
     h5py
-    hdf5plugin
+    hdf5plugin>=4.0.1
     numpy
     pint
     importlib_resources>=1.1

--- a/src/nexgen/nxs_write/__init__.py
+++ b/src/nexgen/nxs_write/__init__.py
@@ -401,7 +401,7 @@ def write_compressed_copy(
             data = fh[dset_key][()]
 
     nxgroup.create_dataset(
-        dset_name, data=data, **Bitshuffle(nelems=block_size, lz4=True)
+        dset_name, data=data, **Bitshuffle(nelems=block_size, cname="lz4")  # lz4=True)
     )
     NXclass_logger.info(
         f"A compressed copy of the {dset_name} has been written into the NeXus file."


### PR DESCRIPTION
Fix the following warning when writing a compressed copy of the pixel mask or flatfield, due to changes in the latest version of `hdf5plugin`.

```Deprecation: hdf5plugin.Bitshuffle's lz4 argument is deprecated, use cname='lz4' or 'none' instead.```