### PR TITLE
Tristan copy pp small fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+##
+
+### Fixed
+- In CopyTristanNexus, `single_image_nexus` now takes number of bins for a static pump-probe experiment as input instead of a flag.
+
 ## 0.6.19
 
 ### Changed

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -75,9 +75,6 @@ Copying tools
     :members:
 
 
-.. automodule:: nexgen.nxs_copy
-    :members:
-
 
 Utilities
 =========

--- a/src/nexgen/nxs_copy/CopyTristanNexus.py
+++ b/src/nexgen/nxs_copy/CopyTristanNexus.py
@@ -25,7 +25,7 @@ def single_image_nexus(
     data_file: Path | str,
     tristan_nexus: Path | str,
     write_mode: str = "x",
-    pump_probe: bool = False,
+    pump_probe_bins: int = None,
 ) -> str:
     """
     Create a NeXus file for a single-image or a stationary pump-probe dataset.
@@ -40,8 +40,8 @@ def single_image_nexus(
         tristan_nexus (Path | str): String or Path pointing to the input NeXus file with experiment metadata to be copied.
         write_mode (str, optional): String indicating writing mode for the output NeXus file.  Accepts any valid
                         h5py file opening mode. Defaults to "x".
-        pump_probe (bool, optional): Indicates if the NeXus file will be linked to a static pump-probe image stack.
-                        Deafults to False.
+        pump_probe_bins (int, optional): If the NeXus file is be linked to a static pump-probe image stack, pass the number
+                        of images the events have been binned into. Deafults to None.
 
     Returns:
         nxs_filename (str): The name of the output NeXus file.
@@ -80,9 +80,8 @@ def single_image_nexus(
                 # was not moved during the data collection, record the rotation axis
                 # position as a scalar.
                 ax_range = nxs_in["entry/data"][ax][()]
-            if pump_probe is True:
-                num_imgs = nxdata["data"].shape[0]
-                ax_range = np.repeat(ax_range, num_imgs)
+            if pump_probe_bins:
+                ax_range = np.repeat(ax_range, pump_probe_bins)
             nxdata.create_dataset(ax, data=np.array([ax_range]))
             # Write the attributes
             for key, value in ax_attr.items():


### PR DESCRIPTION
Change input for `single_image_nexus` from bool to number of bins. This is because python-tristan writes the nexus file before binning so there won't be any data file to look at for the shape.