### PR TITLE
Keep the osc axis constant in fixed target for SSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # CHANGELOG
 
-## 0.6.20
+##
 
+### Added
+- Conversion table for SSX chip from coordinates to block number
+
+### Fixed
+- Oscillation axis end positions being automatically set to 0 instead of metafile value for upwards blocks in SSX chip.
+
+## 0.6.20
 
 ### Added
 - New function in CopyTristanNexus to deal with serial crystallography data.

--- a/src/nexgen/beamlines/SSX_chip.py
+++ b/src/nexgen/beamlines/SSX_chip.py
@@ -68,6 +68,21 @@ class Chip:
         )
 
 
+def fullchip_conversion_table(chip: Chip) -> Dict:
+    coords = []
+    table = {}
+    for i in range(chip.num_blocks[0]):
+        if i % 2 == 0:
+            for j in range(chip.num_blocks[1]):
+                coords.append((i, j))
+        else:
+            for j in range(chip.num_blocks[1] - 1, -1, -1):
+                coords.append((i, j))
+    for k, v in zip(range(1, chip.tot_blocks() + 1), coords):
+        table[f"%0{2}d" % k] = v
+    return table
+
+
 def read_chip_map(mapfile: Path | str, x_blocks: int, y_blocks: int) -> Dict:
     """
     Read the .map file for the current collection on a chip.
@@ -112,6 +127,16 @@ def read_chip_map(mapfile: Path | str, x_blocks: int, y_blocks: int) -> Dict:
             y = val - int(b)
         blocks[b] = (x, y)
     return blocks
+
+
+def fullchip_blocks_conversion(blocks: Dict[Tuple, List], chip: Chip) -> Dict:
+    new_blocks = {}
+    table = fullchip_conversion_table(chip)
+    for kt, vt in table.items():
+        for kb, vb in blocks.items():
+            if kb == vt:
+                new_blocks[kt] = vb
+    return new_blocks
 
 
 def compute_goniometer(

--- a/src/nexgen/beamlines/SSX_expt.py
+++ b/src/nexgen/beamlines/SSX_expt.py
@@ -147,12 +147,6 @@ def run_fixed_target(
     OSC = {osc_axis: np.array([])}
     TRANSL = {"sam_y": np.array([]), "sam_x": np.array([])}
     for _s, _e in zip(start_pos.items(), end_pos.items()):
-        logger.debug(
-            "Current block: \n"
-            f"Starts: {goniometer['starts']} \n"
-            f"Ends: {goniometer['ends']} \n"
-            f"Incs: {goniometer['increments']}"
-        )
         # Determine wheter it's an up or down block
         col = (
             int(_e[0]) // chip.num_blocks[0]
@@ -185,6 +179,12 @@ def run_fixed_target(
                 e[i] if i != Xidx else e[i] - goniometer["increments"][i]
                 for i in range(len(e))
             ]
+        logger.debug(
+            "Current block: \n"
+            f"Starts: {goniometer['starts']} \n"
+            f"Ends: {goniometer['ends']} \n"
+            f"Incs: {goniometer['increments']}"
+        )
         osc, transl = ScanReader(
             goniometer,
             n_images=(

--- a/src/nexgen/beamlines/SSX_expt.py
+++ b/src/nexgen/beamlines/SSX_expt.py
@@ -154,7 +154,11 @@ def run_fixed_target(
             f"Incs: {goniometer['increments']}"
         )
         # Determine wheter it's an up or down block
-        col = int(_e[0]) // 8 if int(_e[0]) % 8 != 0 else (int(_e[0]) // 8) - 1
+        col = (
+            int(_e[0]) // chip.num_blocks[0]
+            if int(_e[0]) % chip.num_blocks[0] != 0
+            else (int(_e[0]) // chip.num_blocks[0]) - 1
+        )
         # Get the values
         if goniometer["starts"] is None:
             s = _s[1]

--- a/src/nexgen/beamlines/SSX_expt.py
+++ b/src/nexgen/beamlines/SSX_expt.py
@@ -143,6 +143,12 @@ def run_fixed_target(
     OSC = {osc_axis: np.array([])}
     TRANSL = {"sam_y": np.array([]), "sam_x": np.array([])}
     for _s, _e in zip(start_pos.items(), end_pos.items()):
+        logger.debug(
+            "Current block: \n"
+            f"Starts: {goniometer['starts']} \n"
+            f"Ends: {goniometer['ends']} \n"
+            f"Incs: {goniometer['increments']}"
+        )
         # Determine wheter it's an up or down block
         col = int(_e[0]) // 8 if int(_e[0]) % 8 != 0 else (int(_e[0]) // 8) - 1
         # Get the values
@@ -167,9 +173,10 @@ def run_fixed_target(
                 end - inc for end, inc in zip(e, goniometer["increments"])
             ]
         else:
-            goniometer["ends"] = len(goniometer["axes"]) * [0.0]
-            goniometer["ends"][Yidx] = e[Yidx]
-            goniometer["ends"][Xidx] = e[Xidx] - goniometer["increments"][Xidx]
+            goniometer["ends"] = [
+                e[i] if i != Xidx else e[i] - goniometer["increments"][i]
+                for i in range(len(e))
+            ]
         osc, transl = ScanReader(
             goniometer,
             n_images=(

--- a/src/nexgen/beamlines/SSX_expt.py
+++ b/src/nexgen/beamlines/SSX_expt.py
@@ -134,7 +134,11 @@ def run_fixed_target(
     # Calculate scan start/end positions on chip
     if list(blocks.values())[0] == "fullchip":
         logger.info("Full chip: all the blocks will be scanned.")
+        from .SSX_chip import fullchip_blocks_conversion
+
         start_pos, end_pos = compute_goniometer(chip, goniometer["axes"], full=True)
+        start_pos = fullchip_blocks_conversion(start_pos, chip)
+        end_pos = fullchip_blocks_conversion(end_pos, chip)
     else:
         logger.info(f"Scanning blocks: {list(blocks.keys())}.")
         start_pos, end_pos = compute_goniometer(chip, goniometer["axes"], blocks=blocks)

--- a/tests/beamlines/test_SSX_chip.py
+++ b/tests/beamlines/test_SSX_chip.py
@@ -6,6 +6,7 @@ from nexgen.beamlines import PumpProbe
 from nexgen.beamlines.SSX_chip import (
     Chip,
     compute_goniometer,
+    fullchip_blocks_conversion,
     fullchip_conversion_table,
     read_chip_map,
 )
@@ -47,7 +48,9 @@ def test_chip_windows():
 
 
 def test_chip_size():
-    pass
+    size = test_chip.chip_size()
+    assert type(size) is tuple
+    assert size == (6.35, 6.35)
 
 
 def test_chip_types():
@@ -71,7 +74,15 @@ def test_fullchip_conversion_table():
 
 
 def test_fullchip_blocks_conversion():
-    pass
+    test_pos = {
+        (0, 0): 4 * [0.0],
+        (0, 1): [0.0, 3.175, 0.0, 0.0],
+        (1, 1): [0.0, 5.55, 3.175, 0.0],
+        (1, 0): [0.0, 2.375, 3.175, 0.0],
+    }
+    new_test_pos = fullchip_blocks_conversion(test_pos, test_chip)
+    assert list(test_pos.values()) == list(new_test_pos.values())
+    assert list(new_test_pos.keys()) == ["01", "02", "03", "04"]
 
 
 @pytest.fixture

--- a/tests/beamlines/test_SSX_chip.py
+++ b/tests/beamlines/test_SSX_chip.py
@@ -3,7 +3,12 @@ import tempfile
 import pytest
 
 from nexgen.beamlines import PumpProbe
-from nexgen.beamlines.SSX_chip import Chip, compute_goniometer, read_chip_map
+from nexgen.beamlines.SSX_chip import (
+    Chip,
+    compute_goniometer,
+    fullchip_conversion_table,
+    read_chip_map,
+)
 
 test_chip = Chip(
     "testchip",
@@ -41,6 +46,10 @@ def test_chip_windows():
     assert test_chip.window_size() == (2.5, 2.5)
 
 
+def test_chip_size():
+    pass
+
+
 def test_chip_types():
     assert type(test_chip.num_steps[0]) is int
     assert type(test_chip.step_size[0]) is float
@@ -52,6 +61,17 @@ def test_no_chip_map_passed_returns_fullchip():
     res = read_chip_map(None, 1, 1)
     assert type(res) is dict
     assert list(res.values())[0] == "fullchip"
+
+
+def test_fullchip_conversion_table():
+    table = fullchip_conversion_table(test_chip)
+    assert len(table) == 4
+    assert list(table.keys()) == ["01", "02", "03", "04"]
+    assert list(table.values()) == [(0, 0), (0, 1), (1, 1), (1, 0)]
+
+
+def test_fullchip_blocks_conversion():
+    pass
 
 
 @pytest.fixture

--- a/tests/beamlines/test_SSX_expt.py
+++ b/tests/beamlines/test_SSX_expt.py
@@ -220,7 +220,7 @@ def test_fixed_target_with_upwards_blocks(dummy_chipmap_file_multi_block):
     # Starts and ends are from the last block
     assert gonio["starts"] == [-90.0, 0.0, 2.375, 3.175]
     ends = [e + i for e, i in zip(gonio["ends"], gonio["increments"])]
-    assert ends == [-90.0, 0.0, 0.0, 5.675]
+    assert ends == [-90.0, 0.0, 0.125, 5.675]
     assert info["n_exposures"] == 1
 
 
@@ -243,5 +243,5 @@ def fixed_target_fullchip_with_multiple_exposures(dummy_chipmap_file_multi_block
     # Starts and ends are from the last block
     assert gonio["starts"] == [-90.0, 0.0, 2.375, 3.175]
     ends = [e + i for e, i in zip(gonio["ends"], gonio["increments"])]
-    assert ends == [-90.0, 0.0, 0.0, 5.675]
+    assert ends == [-90.0, 0.0, 0.125, 5.675]
     assert info["n_exposures"] == 2

--- a/tests/beamlines/test_SSX_expt.py
+++ b/tests/beamlines/test_SSX_expt.py
@@ -224,7 +224,7 @@ def test_fixed_target_with_upwards_blocks(dummy_chipmap_file_multi_block):
     assert info["n_exposures"] == 1
 
 
-def fixed_target_fullchip_with_multiple_exposures(dummy_chipmap_file_multi_block):
+def test_fixed_target_fullchip_with_multiple_exposures(dummy_chipmap_file_multi_block):
     test_goniometer["starts"] = [-90.0, 0.0, 0.0, 0.0]
     test_goniometer["increments"] = None
     test_goniometer["ends"] = [0.0, 0.0, 0.0, 0.0]


### PR DESCRIPTION
There's a miscalculation in the oscillation axis (omega) end values for upwards blocks of the chip. 
Also useful to add a conversion between chip coordinates and block number to avoid errors when using a fullchip.