### PR TITLE
Old Tristan SSX det_z checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Conversion table for SSX chip from coordinates to block number
+- Check and fix for older SSX Tristan datasets which have det_z/distance saved as bytes.
 
 ### Fixed
 - Oscillation axis end positions being automatically set to 0 instead of metafile value for upwards blocks in SSX chip.

--- a/src/nexgen/beamlines/SSX_Eiger_nxs.py
+++ b/src/nexgen/beamlines/SSX_Eiger_nxs.py
@@ -73,7 +73,7 @@ def ssx_eiger_writer(
         exp_time (float): Exposure time, in s.
         det_dist (float): Distance between sample and detector, in mm.
         beam_center (List[float, float]): Beam center position, in pixels.
-        transmission (int): Attenuator transmission, in %.
+        transmission (float): Attenuator transmission, in %.
         wavelength (float): Wavelength of incident beam, in A.
         flux (float): Total flux.
         start_time (datetime): Experiment start time.

--- a/src/nexgen/beamlines/SSX_Tristan_nxs.py
+++ b/src/nexgen/beamlines/SSX_Tristan_nxs.py
@@ -65,7 +65,7 @@ def ssx_tristan_writer(
         exp_time (float): Exposure time, in s.
         det_dist (float): Distance between sample and detector, in mm.
         beam_center (List[float, float]): Beam center position, in pixels.
-        transmission (int): Attenuator transmission, in %.
+        transmission (float): Attenuator transmission, in %.
         wavelength (float): Wavelength of incident beam, in A.
         flux (float): Total flux.
         start_time (datetime): Experiment start time.
@@ -77,11 +77,11 @@ def ssx_tristan_writer(
     """
     # Get info from the beamline
     SSX_TR = ssx_tr_collect(
-        exposure_time=ssx_params["exp_time"],
-        detector_distance=ssx_params["det_dist"],
+        exposure_time=float(ssx_params["exp_time"]),
+        detector_distance=float(ssx_params["det_dist"]),
         beam_center=ssx_params["beam_center"],
-        transmission=ssx_params["transmission"],
-        wavelength=ssx_params["wavelength"],
+        transmission=float(ssx_params["transmission"]),
+        wavelength=float(ssx_params["wavelength"]),
         start_time=ssx_params["start_time"].strftime("%Y-%m-%dT%H:%M:%S")
         if ssx_params["start_time"]
         else None,  # This should be datetiem type

--- a/src/nexgen/nxs_copy/CopyTristanNexus.py
+++ b/src/nexgen/nxs_copy/CopyTristanNexus.py
@@ -12,6 +12,7 @@ import numpy as np
 from ..nxs_write import create_attributes
 from ..nxs_write.NXclassWriters import write_NXnote
 from . import (
+    check_and_fix_det_axis,
     compute_ssx_axes,
     convert_scan_axis,
     get_nexus_tree,
@@ -271,5 +272,10 @@ def serial_images_nexus(
                 for key, value in ax_attr.items():
                     nxdata[ax_name].attrs.create(key, value)
                 convert_scan_axis(nxsample, nxdata, ax_name)
+
+    # Run a quick check on axes values and attributes.
+    # Some ealy serial Tristan data from March/May 2022 have det_z saved as a string
+    with h5py.File(nxs_filename, "r+") as nxs:
+        check_and_fix_det_axis(nxs)
 
     return nxs_filename.as_posix()


### PR DESCRIPTION
Old SSX data on Tristan have the det_z axis and distance written as bytes/strings instead of arrays. Add a check against this when copying the metadata during binning.