### PR TITLE
SSX Eiger data file list improvement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,15 +23,6 @@ repos:
     additional_dependencies: ['flake8-comprehensions==3.8.0']
     args: ['--max-line-length=88', '--select=E401,E711,E712,E713,E714,E721,E722,E901,F401,F402,F403,F405,F631,F632,F633,F811,F812,F821,F822,F841,F901,W191,W291,W292,W293,W602,W603,W604,W605,W606', '--ignore=E203,E266,E402,E501,W503,E741']
 
-# Type checking
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.931
-  hooks:
-    - id: mypy
-      files: 'src/.*\.py$'
-      additional_dependencies: [types-requests]
-      args: ["--ignore-missing-imports", "--no-strict-optional"]
-
 # Other syntax checks
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # CHANGELOG
 
-##
+## 0.6.22
 
 ### Added
 - Added python3.11 support.
-- Added type checking to pre-commit hooks.
 
 ### Changed
+- Fixed the data file list generation for SSX Eiger so that it doesn't need the files to exist yet.
 - Removed python3.7 support.
 
 ## 0.6.21

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,10 +55,6 @@ dev =
 [options.packages.find]
 where = src
 
-[mypy]
-# Ignore missing stubs for modules we use
-ignore_missing_imports = True
-
 [isort]
 profile=black
 float_to_top=true

--- a/src/nexgen/beamlines/SSX_Eiger_nxs.py
+++ b/src/nexgen/beamlines/SSX_Eiger_nxs.py
@@ -54,6 +54,7 @@ def ssx_eiger_writer(
     visitpath: Path | str,
     filename: str,
     beamline: str,
+    num_imgs: int,
     expt_type: str = "fixed-target",
     pump_status: bool = False,
     **ssx_params,
@@ -64,12 +65,12 @@ def ssx_eiger_writer(
         visitpath (Path | str): Collection directory.
         filename (str): Filename root.
         beamline (str): Beamline on which the experiment is being run.
+        num_imgs (int): Total number of images collected.
         expt_type (str, optional): Experiment type, accepted values: extruder,
             fixed-target, 3Dgridscan. Defaults to "fixed-target".
         pump_status (bool, optional): True for pump-probe experiment. Defaults to False.
 
     Keyword Args:
-        num_imgs (int): Total number of images collected.
         exp_time (float): Exposure time, in s.
         det_dist (float): Distance between sample and detector, in mm.
         beam_center (List[float, float]): Beam center position, in pixels.
@@ -91,7 +92,7 @@ def ssx_eiger_writer(
         ValueError: If an invalid experiment type is passed.
     """
     SSX = ssx_collect(
-        num_imgs=int(ssx_params["num_imgs"]),
+        num_imgs=int(num_imgs),
         exposure_time=ssx_params["exp_time"],
         detector_distance=ssx_params["det_dist"]
         if "det_dist" in ssx_params.keys()

--- a/src/nexgen/beamlines/SSX_Eiger_nxs.py
+++ b/src/nexgen/beamlines/SSX_Eiger_nxs.py
@@ -14,7 +14,7 @@ from .. import get_filename_template, get_iso_timestamp, get_nexus_filename, log
 from ..nxs_write.NexusWriter import call_writers
 from ..nxs_write.NXclassWriters import write_NXdatetime, write_NXentry, write_NXnote
 from ..tools.MetaReader import update_detector_axes, update_goniometer
-from ..tools.VDS_tools import image_vds_writer
+from ..tools.VDS_tools import MAX_FRAMES_PER_DATASET, image_vds_writer
 from . import PumpProbe, eiger_meta_links, source
 
 __all__ = ["ssx_eiger_writer"]
@@ -136,8 +136,7 @@ def ssx_eiger_writer(
         raise
 
     # Find datafiles
-    max_imgs_per_file = 1000
-    num_files = math.ceil(SSX.num_imgs / max_imgs_per_file)
+    num_files = math.ceil(SSX.num_imgs / MAX_FRAMES_PER_DATASET)
     filename_template = get_filename_template(metafile)
     filename = [filename_template % i for i in range(1, num_files + 1)]
     logger.info(f"Number of data files to be written: {len(filename)}.")


### PR DESCRIPTION
In order to be able to start writing the nexus file at the beginning of a serial collection, avoid looking for the physical files in the directory and generate the list of data file names from the expected total number of images.