### PR TITLE
Support reading metafile in SWMR mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@ repos:
 
 # Automatic source code formatting
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 22.10.0
   hooks:
   - id: black
     args: [--safe, --quiet]
 
 # Sort imports
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
     name: isort (python)
@@ -17,7 +17,7 @@ repos:
 
 # Linting
 - repo: https://github.com/pycqa/flake8
-  rev: 4.0.1
+  rev: 5.0.4
   hooks:
   - id: flake8
     additional_dependencies: ['flake8-comprehensions==3.8.0']
@@ -25,7 +25,7 @@ repos:
 
 # Other syntax checks
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.2.0
+  rev: v4.3.0
   hooks:
   - id: check-ast
   - id: check-yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## X.X.XX
+
+### Added
+
+### Changed
+- Open metafile with ``swmr=True`` to enable reading during data collection
+
 ## 0.6.22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed
 - Open metafile with ``swmr=True`` to enable reading during data collection
+- Read metafile config items from ``/_dectris/`` rather than ``/config/`` as the former should be accessible when read in SWMR mode during data collection
 
 ## 0.6.22
 

--- a/src/nexgen/beamlines/I19_2_nxs.py
+++ b/src/nexgen/beamlines/I19_2_nxs.py
@@ -218,7 +218,7 @@ def eiger_writer(
     )
 
     # Update axes
-    with h5py.File(TR.meta_file, "r", libver='latest', swmr=True) as mh:
+    with h5py.File(TR.meta_file, "r", libver="latest", swmr=True) as mh:
         update_goniometer(mh, goniometer)
         update_detector_axes(mh, detector)
         logger.info(

--- a/src/nexgen/beamlines/I19_2_nxs.py
+++ b/src/nexgen/beamlines/I19_2_nxs.py
@@ -218,7 +218,7 @@ def eiger_writer(
     )
 
     # Update axes
-    with h5py.File(TR.meta_file, "r") as mh:
+    with h5py.File(TR.meta_file, "r", libver='latest', swmr=True) as mh:
         update_goniometer(mh, goniometer)
         update_detector_axes(mh, detector)
         logger.info(

--- a/src/nexgen/beamlines/SSX_Eiger_nxs.py
+++ b/src/nexgen/beamlines/SSX_Eiger_nxs.py
@@ -183,12 +183,12 @@ def ssx_eiger_writer(
         logger.debug("No wavelength passed, looking for it in the meta file.")
         from ..tools.Metafile import DectrisMetafile
 
-        with h5py.File(metafile, "r") as fh:
+        with h5py.File(metafile, "r", libver='latest', swmr=True) as fh:
             _wl = DectrisMetafile(fh).get_wavelength()
             beam["wavelength"] = _wl
 
     # Look for detector distance
-    with h5py.File(metafile, "r") as fh:
+    with h5py.File(metafile, "r", libver='latest', swmr=True) as fh:
         update_goniometer(fh, goniometer)
         update_detector_axes(fh, detector)
     logger.debug(

--- a/src/nexgen/beamlines/SSX_Eiger_nxs.py
+++ b/src/nexgen/beamlines/SSX_Eiger_nxs.py
@@ -183,12 +183,12 @@ def ssx_eiger_writer(
         logger.debug("No wavelength passed, looking for it in the meta file.")
         from ..tools.Metafile import DectrisMetafile
 
-        with h5py.File(metafile, "r", libver='latest', swmr=True) as fh:
+        with h5py.File(metafile, "r", libver="latest", swmr=True) as fh:
             _wl = DectrisMetafile(fh).get_wavelength()
             beam["wavelength"] = _wl
 
     # Look for detector distance
-    with h5py.File(metafile, "r", libver='latest', swmr=True) as fh:
+    with h5py.File(metafile, "r", libver="latest", swmr=True) as fh:
         update_goniometer(fh, goniometer)
         update_detector_axes(fh, detector)
     logger.debug(

--- a/src/nexgen/command_line/nexus_generator.py
+++ b/src/nexgen/command_line/nexus_generator.py
@@ -846,7 +846,7 @@ def write_with_meta_cli(args):
     logger.info("Looking through _meta.h5 file for metadata.")
     # overwrite detector, overwrite beam, get list of links for nxdetector and nxcollection
 
-    with h5py.File(metafile, "r", libver='latest', swmr=True) as mf:
+    with h5py.File(metafile, "r", libver="latest", swmr=True) as mf:
         overwrite_beam(mf, detector.description, beam)
         link_list = overwrite_detector(mf, detector, ignore)
 

--- a/src/nexgen/command_line/nexus_generator.py
+++ b/src/nexgen/command_line/nexus_generator.py
@@ -846,7 +846,7 @@ def write_with_meta_cli(args):
     logger.info("Looking through _meta.h5 file for metadata.")
     # overwrite detector, overwrite beam, get list of links for nxdetector and nxcollection
 
-    with h5py.File(metafile, "r") as mf:
+    with h5py.File(metafile, "r", libver='latest', swmr=True) as mf:
         overwrite_beam(mf, detector.description, beam)
         link_list = overwrite_detector(mf, detector, ignore)
 

--- a/src/nexgen/nxs_write/NexusWriter.py
+++ b/src/nexgen/nxs_write/NexusWriter.py
@@ -430,7 +430,7 @@ def write_nexus_from_scope(
         )
         do_not_link = params["ignore_meta"]
         # overwrite detector, overwrite beam, get list of links for nxdetector and nxcollection
-        with h5py.File(metafile, "r", libver='latest', swmr=True) as mf:
+        with h5py.File(metafile, "r", libver="latest", swmr=True) as mf:
             overwrite_beam(mf, detector.description, beam)
             link_list = overwrite_detector(mf, detector, do_not_link)
     else:

--- a/src/nexgen/nxs_write/NexusWriter.py
+++ b/src/nexgen/nxs_write/NexusWriter.py
@@ -430,7 +430,7 @@ def write_nexus_from_scope(
         )
         do_not_link = params["ignore_meta"]
         # overwrite detector, overwrite beam, get list of links for nxdetector and nxcollection
-        with h5py.File(metafile, "r") as mf:
+        with h5py.File(metafile, "r", libver='latest', swmr=True) as mf:
             overwrite_beam(mf, detector.description, beam)
             link_list = overwrite_detector(mf, detector, do_not_link)
     else:

--- a/src/nexgen/tools/MetaReader.py
+++ b/src/nexgen/tools/MetaReader.py
@@ -167,7 +167,7 @@ def overwrite_detector(
 
 def update_goniometer(meta_file: h5py.File, goniometer: Dict):
     """
-    Read the axes values from the config/ dataset in the meta file and update the goniometer.
+    Read the axes values from the _dectris/ grouo in the meta file and update the goniometer.
 
     Args:
         meta_file (h5py.File): Handle to Dectris-shaped meta.h5 file.
@@ -178,8 +178,8 @@ def update_goniometer(meta_file: h5py.File, goniometer: Dict):
     )
     meta = DectrisMetafile(meta_file)
 
-    if meta.hasConfig is True:
-        config = meta.read_config_dset()
+    if meta.hasDectrisGroup is True:
+        config = meta.read_dectris_config()
         num = meta.get_number_of_images()
 
         goniometer["starts"] = []
@@ -208,14 +208,14 @@ def update_goniometer(meta_file: h5py.File, goniometer: Dict):
                 overwrite_logger.info(f"Axis {ax} not in meta file, values set to 0.0.")
     else:
         overwrite_logger.warning(
-            "No config/ dataset found in meta file. Goniometer axes value couldn't be updated from here."
+            "No _dectris/ group found in meta file. Goniometer axes value couldn't be updated from here."
         )
         return
 
 
 def update_detector_axes(meta_file: h5py.File, detector: Dict):
     """
-    Read the axes values from the config/ dataset in the meta file and update the detector.
+    Read the axes values from the _dectris/ group in the meta file and update the detector.
 
     Args:
         meta_file (h5py.File): Handle to Dectris-shaped meta.h5 file.
@@ -224,8 +224,8 @@ def update_detector_axes(meta_file: h5py.File, detector: Dict):
     overwrite_logger.info("Get detector axes values from meta file for Eiger detector.")
     meta = DectrisMetafile(meta_file)
 
-    if meta.hasConfig is True:
-        config = meta.read_config_dset()
+    if meta.hasDectrisGroup is True:
+        config = meta.read_dectris_config()
         dist = units_of_length(
             meta.get_detector_distance()
         )  # If Dectris file is correct, this is m.
@@ -245,3 +245,8 @@ def update_detector_axes(meta_file: h5py.File, detector: Dict):
         overwrite_logger.info(f"Position of axis det_z: {dist.to('mm')}.")
 
         detector["ends"] = detector["starts"]
+    else:
+        overwrite_logger.warning(
+            "No _dectris/ group found in meta file. Detector axes value couldn't be updated from here."
+        )
+        return

--- a/src/nexgen/tools/Metafile.py
+++ b/src/nexgen/tools/Metafile.py
@@ -63,12 +63,19 @@ class DectrisMetafile(Metafile):
 
     @cached_property
     def hasConfig(self) -> bool:
-        if "config" in self._handle.keys():
+        if "_dectris" in self._handle.keys():
             return True
         return False
 
     def read_config_dset(self) -> Dict:
-        config = eval(self._handle["config"][()])
+        config = {}
+        for k, v in self._handle["_dectris"].items():
+            v = v[()]
+            if len(v) == 1:
+                v = v[0]
+                if isinstance(v, bytes):
+                    v = v.decode()
+            config[k] = v
         return config
 
     def get_number_of_images(self) -> int:

--- a/src/nexgen/tools/Metafile.py
+++ b/src/nexgen/tools/Metafile.py
@@ -56,18 +56,13 @@ class DectrisMetafile(Metafile):
 
     @cached_property
     def hasDectrisGroup(self) -> bool:
-        for k in self._handle.keys():
-            if "_dectris" in k and isinstance(self._handle[k], h5py.Group):
-                return True
-        return False
-
-    @cached_property
-    def hasConfig(self) -> bool:
-        if "_dectris" in self._handle.keys():
+        if "_dectris" in self._handle.keys() and isinstance(
+            self._handle["_dectris"], h5py.Group
+        ):
             return True
         return False
 
-    def read_config_dset(self) -> Dict:
+    def read_dectris_config(self) -> Dict:
         config = {}
         for k, v in self._handle["_dectris"].items():
             v = v[()]
@@ -79,8 +74,8 @@ class DectrisMetafile(Metafile):
         return config
 
     def get_number_of_images(self) -> int:
-        if self.hasConfig:
-            config = self.read_config_dset()
+        if self.hasDectrisGroup:
+            config = self.read_dectris_config()
             if config["nimages"] >= 1 and config["ntrigger"] == 1:
                 return config["nimages"]
             elif config["nimages"] == 1 and config["ntrigger"] > 1:

--- a/tests/test_VDS_tools.py
+++ b/tests/test_VDS_tools.py
@@ -1,14 +1,16 @@
+import tempfile
+from unittest.mock import MagicMock
+
+import h5py
+import numpy as np
+import pytest
+
 from nexgen.tools.VDS_tools import (
     Dataset,
-    split_datasets,
     create_virtual_layout,
     image_vds_writer,
+    split_datasets,
 )
-import pytest
-import numpy as np
-import tempfile
-import h5py
-from unittest.mock import MagicMock
 
 
 def test_when_get_frames_and_shape_less_than_1000_then_correct():

--- a/tests/test_meta_tools.py
+++ b/tests/test_meta_tools.py
@@ -7,8 +7,6 @@ import pytest
 from nexgen.tools.Metafile import DectrisMetafile, TristanMetafile
 from nexgen.tools.MetaReader import overwrite_beam
 
-dummy_config = '{"nimages": 10, "ntrigger": 1}'
-
 test_detector_size = (512, 1028)  # slow, fast
 test_beam = {"wavelength": 0.0}
 
@@ -28,7 +26,8 @@ def test_Tristan_meta_file():
 def dummy_eiger_meta_file():
     test_hdf_file = tempfile.TemporaryFile()
     test_meta_file = h5py.File(test_hdf_file, "w")
-    test_meta_file["config"] = dummy_config
+    test_meta_file["_dectris/nimages"] = np.array([10])
+    test_meta_file["_dectris/ntrigger"] = np.array([1])
     test_meta_file["_dectris/wavelength"] = np.array([0.6])
     test_meta_file["_dectris/x_pixels_in_detector"] = np.array([test_detector_size[1]])
     test_meta_file["_dectris/y_pixels_in_detector"] = np.array([test_detector_size[0]])
@@ -40,7 +39,13 @@ def test_Eiger_meta_file(dummy_eiger_meta_file):
     assert meta.hasDectrisGroup
     assert meta.hasMask is False and meta.hasFlatfield is False
     assert meta.hasConfig
-    assert meta.read_config_dset() == {"nimages": 10, "ntrigger": 1}
+    assert meta.read_config_dset() == {
+        "nimages": 10,
+        "ntrigger": 1,
+        "wavelength": 0.6,
+        "x_pixels_in_detector": 1028,
+        "y_pixels_in_detector": 512,
+    }
     assert meta.get_number_of_images() == 10
     assert meta.get_detector_size() == test_detector_size
 


### PR DESCRIPTION
To enable running nexgen during data collection. ODIN has the file open for writing in SWMR mode for the duration of data collection.

Read config items from `/_dectris/` instead of `/config/` - the former should be accessible when read in SWMR mode during data collection whereas the latter is added dynamically and isn't accessible until the file is no longer open for writing