### PR TITLE
Optional vds clean up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.6.27
+
+# Changed
+- VDS clean up of unused links in NXmxFileWriter is now optional and set to False by default. It should only be set to True if positive that all the files have already been written.
+
 ## 0.6.26
 
 # Fixed

--- a/src/nexgen/nxs_write/NXmxWriter.py
+++ b/src/nexgen/nxs_write/NXmxWriter.py
@@ -224,17 +224,20 @@ class NXmxFileWriter:
         vds_offset: int = 0,
         vds_shape: Tuple[int, int, int] = None,
         vds_dtype: Any = np.uint16,
+        clean_up: bool = False,
     ):
         """Write a Virtual Dataset.
 
         This method adds a VDS under /entry/data/data in the NeXus file, linking to either the full datasets or the subset defined by \
         vds_offset (used as start index) and vds_shape.
+        WARNING. Only use clean up if the data collection is finished and all the files have already been written.
 
         Args:
             vds_offset (int, optional): Start index for the vds writer. Defaults to 0.
             vds_shape (Tuple[int,int,int], optional): Shape of the data which will be linked in the VDS. If not passed, it will be defined as \
             (tot_num_imgs - start_idx, *image_size). Defaults to None.
             vds_dtype (Any, optional): The type of the input data. Defaults to np.uint16.
+            clean_up(bool, optional): Clean up unused links in vds. Defaults to False.
         """
         if not vds_shape:
             vds_shape = (
@@ -261,11 +264,12 @@ class NXmxFileWriter:
                 vds_shape=vds_shape,
                 data_type=vds_dtype,
             )
-            clean_unused_links(
-                nxs,
-                vds_shape=vds_shape,
-                start_index=vds_offset,
-            )
+            if clean_up is True:
+                clean_unused_links(
+                    nxs,
+                    vds_shape=vds_shape,
+                    start_index=vds_offset,
+                )
 
             # If number of frames in the VDS is lower than the total, nimages in NXcollection should be overwritten to match this
             if vds_shape[0] < self.tot_num_imgs:

--- a/src/nexgen/nxs_write/NXmxWriter.py
+++ b/src/nexgen/nxs_write/NXmxWriter.py
@@ -265,6 +265,7 @@ class NXmxFileWriter:
                 data_type=vds_dtype,
             )
             if clean_up is True:
+                nxmx_logger.warning("Starting clean up of unused links.")
                 clean_unused_links(
                     nxs,
                     vds_shape=vds_shape,


### PR DESCRIPTION
Make clean up of unused links in VDS optional.
Set to False by default.