### PR TITLE
reduce number of offsets from i19 phil templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Unified logging for beamline tools.
 
 ### Fixed
+- SSX cli import issue.
 - Read params from GDA-generated JSON files.
 - Tidy up/clear up obsolete methods.
 - Update and fix documentation.

--- a/src/nexgen/command_line/SSX_cli.py
+++ b/src/nexgen/command_line/SSX_cli.py
@@ -7,8 +7,9 @@ import logging
 from pathlib import Path
 from typing import Tuple
 
-from .. import P, log
+from .. import log
 from ..beamlines.SSX_chip import CHIP_DICT_DEFAULT
+from ..utils import P
 from . import version_parser
 
 logger = logging.getLogger("nexgen.SSX_cli")

--- a/src/nexgen/command_line/cli_utils.py
+++ b/src/nexgen/command_line/cli_utils.py
@@ -284,7 +284,7 @@ def calculate_scan_range(
     Returns:
         Dict[str, ArrayLike]: A dictionary of ("axis_name": axis_range) key-value pairs.
     """
-    if type(axes_names) != list or type(axes_starts) != list or type(axes_ends) != list:
+    if type(axes_names) is not list or type(axes_starts) is not list or type(axes_ends) is not list:
         raise TypeError("Input values for axes must be passed as lists.")
 
     if len(axes_names) == 0:

--- a/src/nexgen/templates/I19-2_Eiger.phil
+++ b/src/nexgen/templates/I19-2_Eiger.phil
@@ -2,7 +2,7 @@ goniometer {
   axes = omega kappa phi sam_z sam_y sam_x
   depends = . omega kappa phi sam_z sam_y
   vectors = -1,0,0,-0.642788,-0.766044,0,-1,0,0,0,0,-1,0,-1,0,-1,0,0
-  offsets = 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+  offsets = 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
   offset_units = mm mm mm mm mm mm
   starts = None
   ends = None

--- a/src/nexgen/templates/I19-2_Tristan.phil
+++ b/src/nexgen/templates/I19-2_Tristan.phil
@@ -2,7 +2,7 @@ goniometer {
   axes = omega kappa phi sam_z sam_y sam_x
   depends = . omega kappa phi sam_z sam_y
   vectors = -1,0,0,-0.642788,-0.766044,0,-1,0,0,0,0,-1,0,-1,0,-1,0,0
-  offsets = 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+  offsets = 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
   offset_units = mm mm mm mm mm mm
   starts = None
   ends = None

--- a/tests/beamlines/test_SSX_chip.py
+++ b/tests/beamlines/test_SSX_chip.py
@@ -69,7 +69,7 @@ def test_read_chip_map(dummy_chipmap_file):
     blocks = read_chip_map(
         dummy_chipmap_file.name, test_chip.num_blocks[0], test_chip.num_blocks[1]
     )
-    assert type(blocks) == dict and len(blocks) == 2
+    assert isinstance(blocks, dict) and len(blocks) == 2
     assert list(blocks.keys()) == ["01", "04"]
 
 


### PR DESCRIPTION
Mark Warren reported an error when using `generate_nexus`:
```
 ERROR - Number of axes 6 doesn't match the lenght of the array list 21.Please check again and make sure that all axes have a matching array of size 3.
```
Tracked down the issue to his phil file having too many values in the goniometer.offset - and this came straight from the template. So I propose we need to reduce the number of 0s in the offset, but I'm not an expert on this so treat this as a discussion topic :smile: 