### PR TITLE
Refactor I19 writer to avoid meta file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Choice to avoid using the meta file for I19-2 data, as long as all relevant information is passed.
 
 ### Changed
-- Write a soft link for /entry/instrument/detector/detector_z in NXdetector, for compatibility with autoPROC.
+- (Temporary) Write a soft link for /entry/instrument/detector/detector_z in NXdetector, for compatibility with autoPROC.
+- Beamline parameters have been tidied up.
 
 
 ## 0.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 - Added possibility to write `end_time_estimated` field in NXmxWriter and refactored `write_NXdatetime`.
+- Choice to avoid using the meta file for I19-2 data, as long as all relevant information is passed.
 
 ### Changed
 - Write a soft link for /entry/instrument/detector/detector_z in NXdetector, for compatibility with autoPROC.

--- a/docs/api_beamlines.rst
+++ b/docs/api_beamlines.rst
@@ -15,11 +15,7 @@ General utilities
 I19-2
 -----
 
-Directly from the python intepreter/ a python script ...
-
-.. autoclass:: nexgen.beamlines.I19_2_nxs.tr_collect
-    :members:
-
+1. Directly from the python intepreter/ a python script ...
 
 The function
 
@@ -33,7 +29,24 @@ can be called from python and depending on the specified detector type will run:
 
 .. autofunction:: nexgen.beamlines.I19_2_nxs.eiger_writer
 
-Interface with GDA ...
+
+Some useful type definitions to use with these methods:
+
+.. autoclass:: nexgen.beamlines.I19_2_nxs.axes
+    :members:
+
+
+.. autoclass:: nexgen.beamlines.I19_2_nxs.det_axes
+    :members:
+
+
+
+.. autoclass:: nexgen.beamlines.I19_2_nxs.tr_collect
+    :members:
+
+
+
+2. Interface with GDA ...
 
 .. autoclass:: nexgen.beamlines.I19_2_gda_nxs.tr_collect
     :members:

--- a/docs/api_beamlines.rst
+++ b/docs/api_beamlines.rst
@@ -82,6 +82,12 @@ Serial crystallography: experiment types
 .. autofunction:: nexgen.beamlines.SSX_expt.run_fixed_target
 
 
+Electron diffraction: Singla writer
+-----------------------------------
+
+.. autofunction:: nexgen.beamlines.ED_singla_nxs.singla_nexus_writer
+
+
 GDA integration tools
 ---------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -122,11 +122,11 @@ Generating new NeXus files
 Generating NXmx-like NeXus files for Electron Diffraction
 =========================================================
 
-Example usage for a dataset collected on Dectris Singla 1M detector:
+Example usage for a dataset collected on Dectris Singla 1M detector using a phil parser:
 
 .. code-block:: console
 
-    ED_nexus singla ED_Singla.phil input.datafiles=FILE_data_*.h5 goniometer.starts=0,0,0,0 \
+    ED_nexus singla-phil ED_Singla.phil input.datafiles=FILE_data_*.h5 goniometer.starts=0,0,0,0 \
     goniometer.ends=900,0,0,0 goniometer.increments=1,0,0,0 detector.starts=400 detector.beam_center=1,1 \
     -m FILE_master.h5
 
@@ -155,14 +155,22 @@ To specify a more specific name for the `/entry/instrument/name` field, the foll
 
 which will result in the instrument name being set to `DIAMOND MICROSCOPE eBic` instead of `DIAMOND eBic`.
 
-In case there is a need to save the NeXus file in a different location than the data files:
+
+The downside of this option is that the external links to the data will now be saved using absolute paths instead of relative.
+
+
+Example usage for a dataset collected on Dectris Singla 1M detector without the phil parser (new as of version `0.7.3`):
+
+.. code-block:: console
+
+    ED_nexus singla FILE_master.h5 400 -e 0.099 -wl 0.02 -bc 1 1 --axis-name alpha --axis-start 0.0 --axis-inc 0.11
+
+
+For both CLI tools, in case there is a need to save the NeXus file in a different location than the data files:
 
 .. code-block:: console
 
     -o /path/to/new/directory
-
-
-The downside of this option is that the external links to the data will now be saved using absolute paths instead of relative.
 
 
 Copying NeXus files

--- a/src/nexgen/beamlines/I19_2_gda_nxs.py
+++ b/src/nexgen/beamlines/I19_2_gda_nxs.py
@@ -131,8 +131,7 @@ def tristan_writer(
 
     collection_summary_log(
         logger,
-        gonio_axes,
-        [scan_axis],
+        goniometer,
         detector,
         attenuator,
         beam,

--- a/src/nexgen/beamlines/I19_2_gda_nxs.py
+++ b/src/nexgen/beamlines/I19_2_gda_nxs.py
@@ -320,7 +320,7 @@ def write_nxs(**tr_params):
 
     # Get some parameters in here
     if "eiger" in TR.detector_name.lower():
-        from .beamline_utils import I19_2Eiger as axes_params
+        from .I19_2_params import I19_2Eiger as axes_params
 
         det_params = EigerDetector(
             "Eiger 2X 4M",
@@ -330,7 +330,7 @@ def write_nxs(**tr_params):
             -1,
         )
     elif "tristan" in TR.detector_name.lower():
-        from .beamline_utils import I19_2Tristan as axes_params
+        from .I19_2_params import I19_2Tristan as axes_params
 
         det_params = TristanDetector("Tristan 10M", (3043, 4183))
     else:

--- a/src/nexgen/beamlines/I19_2_nxs.py
+++ b/src/nexgen/beamlines/I19_2_nxs.py
@@ -318,8 +318,7 @@ def eiger_writer(
 
     collection_summary_log(
         logger,
-        gonio_axes,
-        [scan_axis],
+        goniometer,
         detector,
         attenuator,
         beam,

--- a/src/nexgen/beamlines/I19_2_nxs.py
+++ b/src/nexgen/beamlines/I19_2_nxs.py
@@ -372,7 +372,7 @@ def nexus_writer(
         stop_time (datetime, optional): Experiment end time. Defaults to None.
 
     Keyword Args:
-        num_imgs (int): Total number of images to be collected.
+        n_imgs (int): Total number of images to be collected.
         exposure_time (float): Exposure time, in s.
         transmission (float): Attenuator transmission, in %.
         wavelength (float): Wavelength of incident beam, in A.

--- a/src/nexgen/beamlines/I19_2_nxs.py
+++ b/src/nexgen/beamlines/I19_2_nxs.py
@@ -454,7 +454,7 @@ def nexus_writer(
             raise ValueError(
                 """
                 Missing input parameter n_imgs. \n
-                For and Eiger collection, if meta file is to be ignored, the number of images to
+                For an Eiger collection, if meta file is to be ignored, the number of images to
                 be collected has to be passed to the writer.
                 """
             )

--- a/src/nexgen/beamlines/I19_2_nxs.py
+++ b/src/nexgen/beamlines/I19_2_nxs.py
@@ -93,7 +93,7 @@ def tristan_writer(
             detector, passed from command line. Defaults to None.
     """
     source = Source("I19-2")
-    from .beamline_utils import I19_2Tristan as axes_params
+    from .I19_2_params import I19_2Tristan as axes_params
 
     # Define Tristan params
     tristan_params = TristanDetector("Tristan 10M", (3043, 4183))
@@ -215,7 +215,7 @@ def eiger_writer(
             raise IOError("Missing at least one of axes_pos, det_pos, n_frames.")
 
     source = Source("I19-2")
-    from .beamline_utils import I19_2Eiger as axes_params
+    from .I19_2_params import I19_2Eiger as axes_params
 
     # Define Eiger 4M params
     eiger_params = EigerDetector(

--- a/src/nexgen/beamlines/I19_2_nxs.py
+++ b/src/nexgen/beamlines/I19_2_nxs.py
@@ -434,9 +434,9 @@ def nexus_writer(
         get_iso_timestamp(TR.stop_time),
     )
 
-    if find_in_dict("gonio_pos", params):
+    if not find_in_dict("gonio_pos", params):
         params["gonio_pos"] = None
-    if find_in_dict("det_pos", params):
+    if not find_in_dict("det_pos", params):
         params["det_pos"] = None
 
     if "tristan" in TR.detector_name.lower():
@@ -447,10 +447,10 @@ def nexus_writer(
                 "No scan axis has been specified. Phi will be set as default."
             )
 
-    if find_in_dict("use_meta", params):
+    if not find_in_dict("use_meta", params):
         # If by any chance not passed, assume False
         params["use_meta"] = False
-        if find_in_dict("n_imgs", params) and "eiger" in TR.detector_name:
+        if not find_in_dict("n_imgs", params) and "eiger" in TR.detector_name:
             raise ValueError(
                 """
                 Missing input parameter n_imgs. \n
@@ -464,7 +464,7 @@ def nexus_writer(
         params["det_pos"] = None
 
     if "eiger" in TR.detector_name:
-        if find_in_dict("n_imgs", params):
+        if not find_in_dict("n_imgs", params):
             params["n_imgs"] = None
         eiger_writer(
             master_file,

--- a/src/nexgen/beamlines/I19_2_nxs.py
+++ b/src/nexgen/beamlines/I19_2_nxs.py
@@ -26,7 +26,7 @@ from ..nxs_utils.ScanUtils import calculate_scan_points, identify_osc_axis
 from ..nxs_write.NXmxWriter import EventNXmxFileWriter, NXmxFileWriter
 from ..tools.Metafile import DectrisMetafile
 from ..tools.MetaReader import define_vds_data_type, update_axes_from_meta
-from ..utils import get_iso_timestamp, get_nexus_filename
+from ..utils import find_in_dict, get_iso_timestamp, get_nexus_filename
 from .beamline_utils import collection_summary_log
 
 
@@ -388,7 +388,7 @@ def nexus_writer(
         use_meta (bool): For Eiger, if True use metadata from meta.h5 file. Otherwise \
             will require all other information to be passed manually.
     """
-    if "serial" in list(params.keys()) and params["serial"] is True:
+    if find_in_dict("serial", params) and params["serial"] is True:
         raise ExperimentTypeError(
             "This is writer is not enabled for ssx collections."
             "Pleas look into SSX_Eiger or SSX_Tristan for this functionality."
@@ -407,7 +407,7 @@ def nexus_writer(
     )
 
     # Check that the new NeXus file is to be written in the same directory
-    if "outdir" in list(params.keys()) and params["outdir"]:
+    if find_in_dict("outdir", params) and params["outdir"]:
         wdir = Path(params["outdir"]).expanduser().resolve()
     else:
         wdir = TR.meta_file.parent
@@ -434,9 +434,9 @@ def nexus_writer(
         get_iso_timestamp(TR.stop_time),
     )
 
-    if "gonio_pos" not in list(params.keys()):
+    if find_in_dict("gonio_pos", params):
         params["gonio_pos"] = None
-    if "det_pos" not in list(params.keys()):
+    if find_in_dict("det_pos", params):
         params["det_pos"] = None
 
     if "tristan" in TR.detector_name.lower():
@@ -447,10 +447,10 @@ def nexus_writer(
                 "No scan axis has been specified. Phi will be set as default."
             )
 
-    if "use_meta" not in list(params.keys()):
+    if find_in_dict("use_meta", params):
         # If by any chance not passed, assume False
         params["use_meta"] = False
-        if "n_imgs" not in list(params.keys()) and "eiger" in TR.detector_name:
+        if find_in_dict("n_imgs", params) and "eiger" in TR.detector_name:
             raise ValueError(
                 """
                 Missing input parameter n_imgs. \n
@@ -464,7 +464,7 @@ def nexus_writer(
         params["det_pos"] = None
 
     if "eiger" in TR.detector_name:
-        if "n_imgs" not in list(params.keys()):
+        if find_in_dict("n_imgs", params):
             params["n_imgs"] = None
         eiger_writer(
             master_file,

--- a/src/nexgen/beamlines/I19_2_nxs.py
+++ b/src/nexgen/beamlines/I19_2_nxs.py
@@ -65,7 +65,7 @@ tr_collect.scan_axis.__doc__ = "Rotation scan axis. Must be passed for Tristan."
 
 def tristan_writer(
     master_file: Path,
-    TR: namedtuple,
+    TR: tr_collect,
     timestamps: Tuple[str, str] = (None, None),
     axes_pos: List[namedtuple] = None,
     det_pos: List[namedtuple] = None,
@@ -75,7 +75,7 @@ def tristan_writer(
 
     Args:
         master_file (Path): Path to nexus file to be written.
-        TR (namedtuple): Parameters passed from the beamline.
+        TR (tr_collect): Parameters passed from the beamline.
         timestamps (Tuple[str, str], optional): Collection start and end time. Defaults to (None, None).
         axes_pos (List[namedtuple], optional): List of (axis_name, start, end) values for the goniometer, passed from command line. Defaults to None.
         det_pos (List[namedtuple], optional): List of (axis_name, start) values for the detector, passed from command line. Defaults to None.
@@ -163,7 +163,7 @@ def tristan_writer(
 
 def eiger_writer(
     master_file: Path,
-    TR: namedtuple,
+    TR: tr_collect,
     timestamps: Tuple[str, str] = (None, None),
 ):
     """
@@ -172,7 +172,7 @@ def eiger_writer(
 
     Args:
         master_file (Path): Path to nexus file to be written.
-        TR (namedtuple): Parameters passed from the beamline.
+        TR (tr_collect): Parameters passed from the beamline.
         timestamps (Tuple[str, str], optional): Collection start and end time. Defaults to (None, None).
 
     Raises:
@@ -325,6 +325,8 @@ def nexus_writer(
             from meta_file directory.
         serial (bool): Specify whether it's a serial crystallography dataset.
         det_dist (float): Distance between sample and detector, in mm.
+        use_meta (bool): For Eiger, if True use metadata from meta.h5 file. Otherwise \
+            will require all other information to be passed manually.
     """
     if "serial" in list(params.keys()) and params["serial"] is True:
         raise ExperimentTypeError(

--- a/src/nexgen/beamlines/I19_2_params.py
+++ b/src/nexgen/beamlines/I19_2_params.py
@@ -1,96 +1,38 @@
 """
 Define beamline parameters for I19-2, Tristan and Eiger detectors.
 """
-goniometer_axes = {
-    "axes": ["omega", "kappa", "phi", "sam_z", "sam_y", "sam_x"],
-    "depends": [".", "omega", "kappa", "phi", "sam_z", "sam_y"],
-    "vectors": [
-        (-1, 0, 0),
-        (-0.642788, -0.766044, 0),
-        (-1, 0, 0),
-        (0, 0, -1),
-        (0, -1, 0),
-        (-1, 0, 0),
+
+from ..nxs_utils import Axis, TransformationType
+from ..utils import Point3D
+from .beamline_utils import BeamlineAxes
+
+I19_2_gonio = [
+    Axis("omega", ".", TransformationType.ROTATION, Point3D(-1, 0, 0)),
+    Axis(
+        "kappa", "omega", TransformationType.ROTATION, Point3D(-0.642788, -0.766044, 0)
+    ),
+    Axis("phi", "kappa", TransformationType.ROTATION, Point3D(-1, 0, 0)),
+    Axis("sam_z", "phi", TransformationType.TRANSLATION, Point3D(0, 0, 1)),
+    Axis("sam_y", "sam_z", TransformationType.TRANSLATION, Point3D(0, 1, 0)),
+    Axis("sam_x", "sam_y", TransformationType.TRANSLATION, Point3D(1, 0, 0)),
+]
+
+I19_2Eiger = BeamlineAxes(
+    gonio=I19_2_gonio,
+    det_axes=[
+        Axis("two_theta", ".", TransformationType.ROTATION, Point3D(-1, 0, 0)),
+        Axis("det_z", "two_theta", TransformationType.TRANSLATION, Point3D(0, 0, 1)),
     ],
-    "types": [
-        "rotation",
-        "rotation",
-        "rotation",
-        "translation",
-        "translation",
-        "translation",
+    fast_axis=Point3D(0, 1, 0),
+    slow_axis=Point3D(-1, 0, 0),
+)
+
+I19_2Tristan = BeamlineAxes(
+    gonio=I19_2_gonio,
+    det_axes=[
+        Axis("two_theta", ".", TransformationType.ROTATION, Point3D(-1, 0, 0), 0),
+        Axis("det_z", "two_theta", TransformationType.TRANSLATION, Point3D(0, 0, 1)),
     ],
-    "units": ["deg", "deg", "deg", "mm", "mm", "mm"],
-    "offsets": [(0, 0, 0), (0, 0, 0), (0, 0, 0), (0, 0, 0), (0, 0, 0), (0, 0, 0)],
-    "starts": None,
-    "ends": None,
-    "increments": None,
-}
-
-tristan10M_params = {
-    "mode": "events",
-    "description": "Tristan 10M",
-    "detector_type": "Pixel",
-    "sensor_material": "Si",
-    "sensor_thickness": "0.0005m",
-    "pixel_size": ["5.5e-05m", "5.5e-05m"],
-    "flatfield": "Tristan10M_flat_field_coeff_with_Mo_17.479keV.h5",
-    "flatfield_applied": False,
-    "pixel_mask": "Tristan10M_mask_with_spec.h5",
-    "pixel_mask_applied": False,
-    "image_size": [3043, 4183],  # (slow, fast)
-    "axes": ["two_theta", "det_z"],
-    "depends": [".", "two_theta"],
-    "vectors": [(-1, 0, 0), (0, 0, 1)],
-    "types": ["rotation", "translation"],
-    "units": ["deg", "mm"],
-    "starts": None,
-    "ends": None,
-    "increments": [0.0, 0.0],
-    "software_version": "1.1.3",
-    "detector_tick": "1562.5ps",
-    "detector_frequency": "6.4e+08Hz",
-    "timeslice_rollover": 18,
-}
-
-tristan10M_module = {
-    "fast_axis": [-1, 0, 0],
-    "slow_axis": [0, 1, 0],
-    "module_offset": "1",
-}
-
-eiger4M_params = {
-    "mode": "images",
-    "description": "Eiger 2X 4M",
-    "detector_type": "Pixel",
-    "sensor_material": "CdTe",
-    "sensor_thickness": "0.750mm",
-    "overload": 50649,  # "_dectris/countrate_correction_count_cutoff",
-    "underload": -1,
-    "pixel_size": ["0.075mm", "0.075mm"],
-    "flatfield": "flatfield",
-    "flatfield_applied": "_dectris/flatfield_correction_applied",
-    "pixel_mask": "mask",
-    "pixel_mask_applied": "_dectris/pixel_mask_applied",
-    "image_size": [2162, 2068],  # (slow, fast)
-    "axes": ["two_theta", "det_z"],
-    "depends": [".", "two_theta"],
-    "vectors": [(-1, 0, 0), (0, 0, 1)],
-    "types": ["rotation", "translation"],
-    "units": ["deg", "mm"],
-    "starts": None,
-    "ends": None,
-    "increments": [0.0, 0.0],
-    "bit_depth_readout": "_dectris/bit_depth_image",
-    "bit_depth_image": "_dectris/bit_depth_image",
-    "detector_readout_time": "_dectris/detector_readout_time",
-    "threshold_energy": "_dectris/threshold_energy",
-    "software_version": "_dectris/software_version",
-    "serial_number": "_dectris/detector_number",
-}
-
-eiger4M_module = {
-    "fast_axis": [0, 1, 0],
-    "slow_axis": [-1, 0, 0],
-    "module_offset": "1",
-}
+    fast_axis=Point3D(-1, 0, 0),
+    slow_axis=Point3D(0, 1, 0),
+)

--- a/src/nexgen/beamlines/I24_params.py
+++ b/src/nexgen/beamlines/I24_params.py
@@ -1,6 +1,34 @@
 """
-Define beamline parameters for I24 with Eiger 9M detector.
+Define beamline parameters for I24 with Eiger 9M and Jungfrau 1M detectors.
 """
+
+from ..nxs_utils import Axis, TransformationType
+from ..utils import Point3D
+from .beamline_utils import BeamlineAxes
+
+I24Eiger = BeamlineAxes(
+    gonio=[
+        Axis("omega", ".", TransformationType.ROTATION, Point3D(-1, 0, 0)),
+        Axis("sam_z", "omega", TransformationType.TRANSLATION, Point3D(0, 0, 1)),
+        Axis("sam_y", "sam_z", TransformationType.TRANSLATION, Point3D(0, 1, 0)),
+        Axis("sam_x", "sam_y", TransformationType.TRANSLATION, Point3D(1, 0, 0)),
+    ],
+    det_axes=[Axis("det_z", ".", TransformationType.TRANSLATION, Point3D(0, 0, 1))],
+    fast_axis=Point3D(-1, 0, 0),
+    slow_axis=Point3D(0, -1, 0),
+)
+
+I24Jungfrau = BeamlineAxes(
+    gonio=[
+        Axis("omega", ".", TransformationType.ROTATION, Point3D(0, 1, 0)),
+        Axis("sam_z", "omega", TransformationType.TRANSLATION, Point3D(0, 0, 1)),
+        Axis("sam_y", "sam_z", TransformationType.TRANSLATION, Point3D(0, 1, 0)),
+        Axis("sam_x", "sam_y", TransformationType.TRANSLATION, Point3D(1, 0, 0)),
+    ],
+    det_axes=[Axis("det_z", ".", TransformationType.TRANSLATION, Point3D(0, 0, 1))],
+    fast_axis=Point3D(-1, 0, 0),
+    slow_axis=Point3D(0, -1, 0),
+)
 
 goniometer_axes = {
     "axes": ["omega", "sam_z", "sam_y", "sam_x"],

--- a/src/nexgen/beamlines/SSX_Eiger_nxs.py
+++ b/src/nexgen/beamlines/SSX_Eiger_nxs.py
@@ -295,8 +295,7 @@ def ssx_eiger_writer(
     # Log a bunch of stuff
     collection_summary_log(
         logger,
-        gonio_axes,
-        list(SCAN.keys()),
+        goniometer,
         detector,
         attenuator,
         beam,

--- a/src/nexgen/beamlines/SSX_Eiger_nxs.py
+++ b/src/nexgen/beamlines/SSX_Eiger_nxs.py
@@ -3,10 +3,6 @@ Create a NeXus file for serial crystallography datasets collected on Eiger detec
 """
 from __future__ import annotations
 
-"""
-Create a NeXus file for serial crystallography datasets collected on Eiger detector either on I19-2 or I24 beamlines.
-"""
-
 import logging
 from collections import namedtuple
 from pathlib import Path
@@ -129,7 +125,7 @@ def ssx_eiger_writer(
     if "I19" in beamline.upper():
         source = Source("I19-2")
         osc_axis = ssx_params["osc_axis"] if "osc_axis" in ssx_params.keys() else "phi"
-        from .beamline_utils import I19_2Eiger as axes_params
+        from .I19_2_params import I19_2Eiger as axes_params
 
         eiger_params = EigerDetector(
             "Eiger 2X 4M",
@@ -141,7 +137,7 @@ def ssx_eiger_writer(
     elif "I24" in beamline.upper():
         source = Source("I24")
         osc_axis = "omega"
-        from .beamline_utils import I24Eiger as axes_params
+        from .I24_params import I24Eiger as axes_params
 
         eiger_params = EigerDetector(
             "Eiger 2X 9M",

--- a/src/nexgen/beamlines/SSX_Tristan_nxs.py
+++ b/src/nexgen/beamlines/SSX_Tristan_nxs.py
@@ -113,11 +113,11 @@ def ssx_tristan_writer(
     logger.info(f"DLS Beamline: {beamline.upper()}.")
     if "I19" in beamline.upper():
         source = Source("I19-2")
-        from .beamline_utils import I19_2Tristan as axes_params
+        from .I19_2_params import I19_2Tristan as axes_params
 
     elif "I24" in beamline.upper():
         source = Source("I19-2")
-        from .beamline_utils import I24Eiger as axes_params
+        from .I24_params import I24Eiger as axes_params
 
         axes_params.fast_axis = Point3D(-1, 0, 0)
         axes_params.slow_axis = Point3D(0, 1, 0)

--- a/src/nexgen/beamlines/SSX_Tristan_nxs.py
+++ b/src/nexgen/beamlines/SSX_Tristan_nxs.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from .. import log
 from ..nxs_utils import Attenuator, Beam, Detector, Goniometer, Source, TristanDetector
 from ..nxs_write.NXmxWriter import EventNXmxFileWriter
-from ..utils import Point3D, get_iso_timestamp
+from ..utils import Point3D, find_in_dict, get_iso_timestamp
 from .beamline_utils import collection_summary_log
 
 # Define a logger object and a formatter
@@ -64,21 +64,38 @@ def ssx_tristan_writer(
         chipmap (Path | str): Path to the chipmap file corresponding to the experiment,
             or 'fullchip' indicating that the whole chip is being scanned.
     """
+    if not find_in_dict("start_time", ssx_params):
+        ssx_params["start_time"] = None
+    if not find_in_dict("stop_time", ssx_params):
+        ssx_params["stop_time"] = None
+
     # Get info from the beamline
     SSX_TR = ssx_tr_collect(
-        exposure_time=float(ssx_params["exp_time"]),
-        detector_distance=float(ssx_params["det_dist"]),
-        beam_center=ssx_params["beam_center"],
-        transmission=float(ssx_params["transmission"]),
-        wavelength=float(ssx_params["wavelength"]),
+        exposure_time=float(ssx_params["exp_time"])
+        if find_in_dict("exp_time", ssx_params)
+        else None,
+        detector_distance=float(ssx_params["det_dist"])
+        if find_in_dict("det_dist", ssx_params)
+        else None,
+        beam_center=ssx_params["beam_center"]
+        if find_in_dict("beam_center", ssx_params)
+        else (0, 0),
+        transmission=float(ssx_params["transmission"])
+        if find_in_dict("transmission", ssx_params)
+        else None,
+        wavelength=float(ssx_params["wavelength"])
+        if find_in_dict("wavelength", ssx_params)
+        else None,
         start_time=ssx_params["start_time"].strftime("%Y-%m-%dT%H:%M:%S")
         if ssx_params["start_time"]
         else None,  # This should be datetiem type
         stop_time=ssx_params["stop_time"].strftime("%Y-%m-%dT%H:%M:%S")
         if ssx_params["stop_time"]
         else None,  # idem.
-        chipmap=ssx_params["chipmap"] if ssx_params["chipmap"] else None,
-        chip_info=ssx_params["chip_info"] if ssx_params["chip_info"] else None,
+        chipmap=ssx_params["chipmap"] if find_in_dict("chipmap", ssx_params) else None,
+        chip_info=ssx_params["chip_info"]
+        if find_in_dict("chip_info", ssx_params)
+        else None,
     )
 
     visitpath = Path(visitpath).expanduser().resolve()

--- a/src/nexgen/beamlines/SSX_Tristan_nxs.py
+++ b/src/nexgen/beamlines/SSX_Tristan_nxs.py
@@ -175,8 +175,7 @@ def ssx_tristan_writer(
 
     collection_summary_log(
         logger,
-        gonio_axes,
-        ["sam_y", "sam_x"],
+        goniometer,
         detector,
         attenuator,
         beam,

--- a/src/nexgen/beamlines/beamline_utils.py
+++ b/src/nexgen/beamlines/beamline_utils.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple
 
 from dataclasses_json import DataClassJsonMixin
 
-from nexgen.nxs_utils import Attenuator, Axis, Beam, Detector, Source
+from nexgen.nxs_utils import Attenuator, Axis, Beam, Detector, Goniometer, Source
 from nexgen.utils import Point3D
 
 
@@ -53,8 +53,7 @@ class BeamlineAxes:
 
 def collection_summary_log(
     logger: logging.Logger,
-    gonio_axes: List[Axis],
-    scan_axis: List[str],
+    goniometer: Goniometer,
     detector: Detector,
     attenuator: Attenuator,
     beam: Beam,
@@ -63,34 +62,13 @@ def collection_summary_log(
 ):
     """General function to log a collection summary."""
     logger.info("--- COLLECTION SUMMARY ---")
-    logger.info("Source information")
-    logger.info(f"Facility: {source.name} - {source.facility_type}.")
-    logger.info(f"Beamline / instrument: {source.beamline}")
-    if source.probe:
-        logger.info(f"Probe: {source.probe}")
+    logger.info(source.__repr__())
 
     logger.info(f"Incident beam wavelength: {beam.wavelength}")
     logger.info(f"Attenuation: {attenuator.transmission}")
 
-    logger.info(f"Scan axis/axes: {scan_axis}")
-
-    logger.info("Goniometer information")
-    for ax in gonio_axes:
-        logger.info(
-            f"Goniometer axis: {ax.name} => {ax.start_pos}, {ax.transformation_type} on {ax.depends}"
-        )
-    logger.info("Detector information")
-    logger.info(f"Detector in use: {detector.detector_params.description}")
-    logger.info(
-        f"Sensor made of {detector.detector_params.sensor_material} x {detector.detector_params.sensor_thickness}"
-    )
-    logger.info(
-        f"Detector is a {detector.detector_params.image_size[::-1]} array of {detector.detector_params.pixel_size} pixels"
-    )
-    for ax in detector.detector_axes:
-        logger.info(
-            f"Detector axis: {ax.name} => {ax.start_pos}, {ax.transformation_type} on {ax.depends}"
-        )
+    logger.info(goniometer.__repr__())
+    logger.info(detector.__repr__)
 
     logger.info(f"Recorded beam center is: {detector.beam_center}.")
     logger.info(f"Recorded exposure time: {detector.exp_time} s.")

--- a/src/nexgen/beamlines/beamline_utils.py
+++ b/src/nexgen/beamlines/beamline_utils.py
@@ -9,14 +9,7 @@ from typing import List, Optional, Tuple
 
 from dataclasses_json import DataClassJsonMixin
 
-from nexgen.nxs_utils import (
-    Attenuator,
-    Axis,
-    Beam,
-    Detector,
-    Source,
-    TransformationType,
-)
+from nexgen.nxs_utils import Attenuator, Axis, Beam, Detector, Source
 from nexgen.utils import Point3D
 
 
@@ -56,62 +49,6 @@ class BeamlineAxes:
             self.fast_axis = Point3D(*self.fast_axis)
         if not isinstance(self.slow_axis, Point3D):
             self.slow_axis = Point3D(*self.slow_axis)
-
-
-# I24
-I24Eiger = BeamlineAxes(
-    gonio=[
-        Axis("omega", ".", TransformationType.ROTATION, (-1, 0, 0)),
-        Axis("sam_z", "omega", TransformationType.TRANSLATION, (0, 0, 1)),
-        Axis("sam_y", "sam_z", TransformationType.TRANSLATION, (0, 1, 0)),
-        Axis("sam_x", "sam_y", TransformationType.TRANSLATION, (1, 0, 0)),
-    ],
-    det_axes=[Axis("det_z", ".", TransformationType.TRANSLATION, (0, 0, 1))],
-    fast_axis=Point3D(-1, 0, 0),
-    slow_axis=Point3D(0, -1, 0),
-)
-
-I24Jungfrau = BeamlineAxes(
-    gonio=[
-        Axis("omega", ".", TransformationType.ROTATION, (0, 1, 0)),
-        Axis("sam_z", "omega", TransformationType.TRANSLATION, (0, 0, 1)),
-        Axis("sam_y", "sam_z", TransformationType.TRANSLATION, (0, 1, 0)),
-        Axis("sam_x", "sam_y", TransformationType.TRANSLATION, (1, 0, 0)),
-    ],
-    det_axes=[Axis("det_z", ".", TransformationType.TRANSLATION, (0, 0, 1))],
-    fast_axis=Point3D(-1, 0, 0),
-    slow_axis=Point3D(0, -1, 0),
-)
-
-# I19-2
-I19_2_gonio = [
-    Axis("omega", ".", TransformationType.ROTATION, (-1, 0, 0)),
-    Axis("kappa", "omega", TransformationType.ROTATION, (-0.642788, -0.766044, 0)),
-    Axis("phi", "kappa", TransformationType.ROTATION, (-1, 0, 0)),
-    Axis("sam_z", "phi", TransformationType.TRANSLATION, (0, 0, 1)),
-    Axis("sam_y", "sam_z", TransformationType.TRANSLATION, (0, 1, 0)),
-    Axis("sam_x", "sam_y", TransformationType.TRANSLATION, (1, 0, 0)),
-]
-
-I19_2Eiger = BeamlineAxes(
-    gonio=I19_2_gonio,
-    det_axes=[
-        Axis("two_theta", ".", TransformationType.ROTATION, (-1, 0, 0)),
-        Axis("det_z", "two_theta", TransformationType.TRANSLATION, (0, 0, 1)),
-    ],
-    fast_axis=Point3D(0, 1, 0),
-    slow_axis=Point3D(-1, 0, 0),
-)
-
-I19_2Tristan = BeamlineAxes(
-    gonio=I19_2_gonio,
-    det_axes=[
-        Axis("two_theta", ".", TransformationType.ROTATION, (-1, 0, 0), 0),
-        Axis("det_z", "two_theta", TransformationType.TRANSLATION, (0, 0, 1)),
-    ],
-    fast_axis=Point3D(-1, 0, 0),
-    slow_axis=Point3D(0, 1, 0),
-)
 
 
 def collection_summary_log(

--- a/src/nexgen/command_line/I19_2_cli.py
+++ b/src/nexgen/command_line/I19_2_cli.py
@@ -55,7 +55,7 @@ def nexgen_writer(args):
     """
     logger.info("Create a NeXus file for I19-2 data.")
 
-    from ..beamlines.I19_2_nxs import nexus_writer  # axes, det_axes, nexus_writer
+    from ..beamlines.I19_2_nxs import axes, det_axes, nexus_writer
 
     if args.axes and not args.ax_start:
         raise OSError(
@@ -75,21 +75,19 @@ def nexgen_writer(args):
 
     if args.axes and args.ax_start:
         if args.detector_name == "eiger":
-            axes = namedtuple("axes", ("id", "start", "inc"))
             axes_list = []
             for ax, s, i in zip(args.axes, args.ax_start, args.ax_inc):
-                axes_list.append(axes(ax, s, i))
+                axes_list.append(axes(id=ax, start=s, inc=i))
         else:
             axes = namedtuple("axes", ("id", "start", "end"))
             axes_list = []
             for ax, s, e in zip(args.axes, args.ax_start, args.ax_end):
-                axes_list.append(axes(ax, s, e))
+                axes_list.append(axes(id=ax, start=s, end=e))
 
     if args.det_axes and args.det_start:
-        det_axes = namedtuple("det_axes", ("id", "start"))
         det_list = []
         for ax, s in zip(args.det_axes, args.det_start):
-            det_list.append(det_axes(ax, s))
+            det_list.append(det_axes(id=ax, start=s))
 
     # Check that an actual meta file has been passed and not a data file
     if "meta" not in args.meta_file:

--- a/src/nexgen/command_line/I19_2_cli.py
+++ b/src/nexgen/command_line/I19_2_cli.py
@@ -66,6 +66,13 @@ def nexgen_writer(args):
             "Please pass start and increment values for each of the detector axes indicated."
         )
 
+    if args.detector_name == "eiger" and not args.use_meta:
+        if not args.axes or not args.det_axes:
+            logger.error(
+                "If not using the metadata from the meta_file please pass all axes values."
+            )
+            raise OSError("Missing axes values.")
+
     if args.axes and args.ax_start:
         if args.detector_name == "eiger":
             axes = namedtuple("axes", ("id", "start", "inc"))
@@ -110,6 +117,7 @@ def nexgen_writer(args):
         gonio_pos=axes_list if args.axes else None,
         det_pos=det_list if args.det_axes else None,
         outdir=args.output if args.output else None,
+        use_meta=args.use_meta,
     )
 
 
@@ -231,6 +239,11 @@ parser_nex.add_argument(
     "--output",
     type=str,
     help="Output directory for new NeXus file, if different from collection directory.",
+)
+parser_nex.add_argument(
+    "--use-meta",
+    action="store_true",
+    help="If passed, for Eiger metadata will be read from meta.h5 file. No action for Tristan.",
 )
 parser_nex.set_defaults(func=nexgen_writer)
 

--- a/src/nexgen/command_line/I19_2_cli.py
+++ b/src/nexgen/command_line/I19_2_cli.py
@@ -55,7 +55,7 @@ def nexgen_writer(args):
     """
     logger.info("Create a NeXus file for I19-2 data.")
 
-    from ..beamlines.I19_2_nxs import nexus_writer
+    from ..beamlines.I19_2_nxs import nexus_writer  # axes, det_axes, nexus_writer
 
     if args.axes and not args.ax_start:
         raise OSError(

--- a/src/nexgen/nxs_utils/Detector.py
+++ b/src/nexgen/nxs_utils/Detector.py
@@ -188,8 +188,8 @@ class Detector:
     def __repr__(self) -> str:
         det_msg = (
             f"{self.detector_params.description} \n\t"
-            f"Image size {self.detector_params.image_size} pixels; \n\t"
-            f"{self.detector_params.sensor_material} sensor x {self.detector_params.sensor_thickness}; \n"
+            f"Image size {self.detector_params.image_size} pixels of size {self.detector_params.pixel_size}; \n\t"
+            f"{self.detector_params.sensor_material} sensor x {self.detector_params.sensor_thickness}; \n\t"
             "Detector axes: \n\t"
         )
         for ax in self.detector_axes:

--- a/src/nexgen/nxs_write/NXmxWriter.py
+++ b/src/nexgen/nxs_write/NXmxWriter.py
@@ -94,6 +94,9 @@ class NXmxFileWriter:
         else:
             return self.filename.parent / f"{self.filename.stem}_meta.h5"
 
+    def _get_collection_time(self):
+        return self.detector.exp_time * self.tot_num_imgs
+
     def _get_data_files_list(
         self,
         image_filename: str | None = None,
@@ -199,6 +202,10 @@ class NXmxFileWriter:
             # Start and estimated end time if known
             if start_time:
                 write_NXdatetime(nxs, start_time, "start_time")
+                if not est_end_time:
+                    tot_exp_time = self._get_collection_time()
+                    est_end = calculate_estimated_end_time(start_time, tot_exp_time)
+                    write_NXdatetime(nxs, est_end, "end_time_estimated")
             if est_end_time:
                 write_NXdatetime(nxs, est_end_time, "end_time_estimated")
 
@@ -478,9 +485,6 @@ class EDNXmxFileWriter(NXmxFileWriter):
             self.detector.fast_axis = coord2mcstas(self.detector.fast_axis, mat)
             self.detector.slow_axis = coord2mcstas(self.detector.slow_axis, mat)
 
-    def _get_collection_time(self):
-        return self.detector.exp_time * self.tot_num_imgs
-
     def _get_data_filename(self) -> List[Path]:
         image_filename = f"{self.filename.stem}_data_000001.h5"
         return self.filename.parent / f"{image_filename}"
@@ -539,7 +543,7 @@ class EDNXmxFileWriter(NXmxFileWriter):
 
             if start_time:
                 write_NXdatetime(nxs, start_time, "start_time")
-                tot_exp_time = self._get_collection_time()
+                tot_exp_time = super()._get_collection_time()
                 est_end = calculate_estimated_end_time(start_time, tot_exp_time)
                 write_NXdatetime(nxs, est_end, "end_time_estimated")
 

--- a/src/nexgen/nxs_write/write_utils.py
+++ b/src/nexgen/nxs_write/write_utils.py
@@ -125,7 +125,7 @@ def calculate_estimated_end_time(
 
     if isinstance(start_time, str):
         start_time = start_time.format("%Y-%m-%dT%H:%M:%S")
-        start_time = datetime.strptime(start_time, time_format.removesuffix("Z"))
+        start_time = datetime.strptime(start_time.strip("Z"), time_format.strip("Z"))
 
     est_end = start_time + timedelta(seconds=tot_collection_time)
     return est_end.strftime(time_format)

--- a/tests/beamlines/test_SSXwriters.py
+++ b/tests/beamlines/test_SSXwriters.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+import pytest
+
+from nexgen.beamlines.SSX_Eiger_nxs import ssx_eiger_writer
+
+
+@patch("nexgen.beamlines.SSX_Eiger_nxs.ssx_collect")
+def test_writer_fails_for_Wrong_expt_type(fake_ssx_collect):
+    with pytest.raises(ValueError):
+        ssx_eiger_writer(
+            "/path/to/file",
+            "somefile",
+            "i24",
+            1,
+            expt_type="aaa",
+        )
+
+
+@patch("nexgen.beamlines.SSX_Eiger_nxs.ssx_collect")
+@patch("nexgen.beamlines.SSX_Eiger_nxs.log")
+def test_writer_fails_for_beamline_not_i24_or_i19(fake_log, fake_ssx):
+    with pytest.raises(ValueError):
+        ssx_eiger_writer(
+            "/path/to/file",
+            "somefile",
+            "i23",
+            1,
+        )

--- a/tests/beamlines/test_i19nxs.py
+++ b/tests/beamlines/test_i19nxs.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nexgen.beamlines.I19_2_nxs import ExperimentTypeError, eiger_writer, nexus_writer
+
+
+def test_nexus_writer_raises_error_for_serial():
+    with pytest.raises(ExperimentTypeError):
+        nexus_writer("/path/to/meta", "eiger", 0.1, serial=True)
+
+
+@patch("nexgen.beamlines.I19_2_nxs.log")
+def test_nexus_writer_fails_if_missing_n_imgs_and_not_using_meta(fake_log):
+    with pytest.raises(ValueError):
+        nexus_writer("/path/to/meta", "eiger", 0.1, use_meta=False)
+
+
+@patch("nexgen.beamlines.I19_2_nxs.tr_collect")
+def test_eiger_nxs_writer_fails_if_missing_axes_and_no_meta(fake_tr):
+    with pytest.raises(ValueError):
+        eiger_writer(Path("/path/to/meta"), fake_tr, use_meta=False)

--- a/tests/nxs_write/test_write_utils.py
+++ b/tests/nxs_write/test_write_utils.py
@@ -1,7 +1,10 @@
+from datetime import datetime
+
 import numpy as np
 import pytest
 
 from nexgen.nxs_write.write_utils import (
+    calculate_estimated_end_time,
     calculate_origin,
     create_attributes,
     find_number_of_images,
@@ -61,3 +64,15 @@ def test_find_number_of_images_returns_0_if_no_file_passed():
 def test_write_copy_raises_error_if_both_array_and_file():
     with pytest.raises(ValueError):
         write_compressed_copy("", "", np.array([0.0]), "filename")
+
+
+def test_calculate_estimated_end_time_from_iso_string():
+    timestamp_str = "2023-11-15T10:30:42Z"
+    est_end_time = calculate_estimated_end_time(timestamp_str, 10)
+    assert est_end_time == "2023-11-15T10:30:52Z"
+
+
+def test_calculate_estimated_end_time_from_datetime():
+    timestamp = datetime.strptime("2023-11-15T10:30:42", "%Y-%m-%dT%H:%M:%S")
+    est_end_time = calculate_estimated_end_time(timestamp, 20)
+    assert est_end_time == "2023-11-15T10:31:02Z"


### PR DESCRIPTION
Closes #142 

The non-gda I19 writer for Eiger should have the option of not using the meta file to update axis/beam/etc... information but get them from input arguments.
The data type for the vds in this case should be set as native int.